### PR TITLE
Boxel::ProgressIcon component

### DIFF
--- a/app/components/boxel/progress-icon/index.hbs
+++ b/app/components/boxel/progress-icon/index.hbs
@@ -1,0 +1,11 @@
+<div
+  class="progress-icon {{if @isCancelled "cancelled"}} {{if @isComplete "complete"}}"
+  style={{this.elementStyle}}
+  ...attributes
+>
+  {{#if (not (or @isCancelled @isComplete))}}
+    <div class="progress-icon__progress-pie" style={{html-safe (concat "stroke-dasharray:" (mult @fractionComplete 60) " " 60)}}>
+      {{svg-jar "progress-circle" width=@size height=@size}}
+    </div>
+  {{/if}}
+</div>

--- a/app/components/boxel/progress-icon/index.js
+++ b/app/components/boxel/progress-icon/index.js
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+import { htmlSafe } from '@ember/template';
+
+export default class extends Component {
+  get elementStyle() {
+    let { size } = this.args;
+    let styles = [
+      `width: ${size}px`,
+      `height: ${size}px`
+    ]
+    if (this.args.isCancelled || this.args.isComplete) {
+      styles.push(
+        `background-size: ${size * 0.666}px ${size * 0.666}px`
+      );
+    }
+    return htmlSafe(styles.join(';'));
+  }
+}

--- a/app/components/boxel/progress-icon/usage.hbs
+++ b/app/components/boxel/progress-icon/usage.hbs
@@ -1,0 +1,51 @@
+<FreestyleAnnotation @slug="progress-icon">
+  <div>
+    @size (Number) the size of the circle, in px.
+    <input
+      type="range"
+      min={{10}}
+      max={{60}}
+      step={{1}}
+      value={{this.size}}
+      {{on 'input' (pick 'target.value' (fn (mut this.size)))}}
+    /> ({{this.size}})
+  </div>
+  <div>
+    @isCancelled (Boolean) when true shows an "x" icon.
+    <input
+      type="checkbox"
+      checked={{this.isCancelled}}
+      {{on 'input' (pick 'target.checked' (fn (mut this.isCancelled)))}}
+    /> ({{this.isCancelled}})
+  </div>
+  <div>
+    @isComplete (Boolean) when true shows an "x" icon.
+    <input
+      type="checkbox"
+      checked={{this.isComplete}}
+      {{on 'input' (pick 'target.checked' (fn (mut this.isComplete)))}}
+    /> ({{this.isComplete}})
+  </div>
+  <div>
+    @fractionComplete (Number) completeness from 0 to 1.
+    <input
+      type="range"
+      min={{0}}
+      max={{1}}
+      step={{0.001}}
+      value={{this.fractionComplete}}
+      {{on 'input' (pick 'target.value' (fn (mut this.fractionComplete)))}}
+    /> ({{this.fractionComplete}})
+  </div>
+</FreestyleAnnotation>
+
+<FreestyleUsage @slug="progress-icon">
+  <Doc::DarkThemeAndLightTheme>
+    <Boxel::ProgressIcon
+      @size={{this.size}}
+      @isCancelled={{this.isCancelled}}
+      @isComplete={{this.isComplete}}
+      @fractionComplete={{this.fractionComplete}}
+    />
+  </Doc::DarkThemeAndLightTheme>
+</FreestyleUsage>

--- a/app/components/boxel/progress-icon/usage.js
+++ b/app/components/boxel/progress-icon/usage.js
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+
+export default class extends Component {
+  fractionComplete = 0.4;
+  size = 24;
+  isCancelled = false;
+  isComplete = false;
+}

--- a/app/components/doc/dark-theme-and-light-theme/index.hbs
+++ b/app/components/doc/dark-theme-and-light-theme/index.hbs
@@ -1,0 +1,9 @@
+<div class="doc-dark-theme-and-light-theme">
+  <div class="doc-dark-theme-and-light-theme__container boxel--dark-theme">
+    {{yield}}
+  </div>
+
+  <div class="doc-dark-theme-and-light-theme__container boxel--light-theme">
+    {{yield}}
+  </div>
+</div>

--- a/app/components/queue-card.hbs
+++ b/app/components/queue-card.hbs
@@ -1,4 +1,4 @@
-<div role="button" {{on "click" @selectCard}} class="queue-card {{if (and (eq @card.id @currentCard.id) (eq @card.orgId @currentCard.orgId)) "queue-card--light-theme"}}">
+<div role="button" {{on "click" @selectCard}} class="queue-card {{if (and (eq @card.id @currentCard.id) (eq @card.orgId @currentCard.orgId)) "boxel--light-theme" "boxel--dark-theme"}}">
   <div class="queue-card__datetime-row">
     {{#let (if @currentMilestone.timestamp @currentMilestone.timestamp @card.datetime) as |datetime|}}
       <time datetime={{datetime}} class="queue-card__datetime">{{moment-format datetime "MMM D, h:mm A"}}</time>
@@ -37,13 +37,12 @@
       </div>
       <div class="queue-card__status">
         {{this.progress}}
-        <div class="queue-card__progress-icon {{if @card.isCancelled "cancelled"}} {{if @card.isComplete "complete"}}">
-          {{#if (not (or @card.isCancelled @card.isComplete))}}
-            <div class="queue-card__progress-pie" style={{html-safe (concat "stroke-dasharray:" (mult this.progressPct 60) " " 60)}}>
-              {{svg-jar "progress-circle" width="24px" height="24px"}}
-            </div>
-          {{/if}}
-        </div>
+        <Boxel::ProgressIcon
+          @isCancelled={{@card.isCancelled}}
+          @isComplete={{@card.isComplete}}
+          @fractionComplete={{div @card.progressPct 100}}
+          @size={{24}}
+        />
       </div>
     </footer>
   {{/if}}

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -12,6 +12,7 @@
 @import '/assets/components/cardflow.css';
 @import '/assets/components/collection-add-button.css';
 @import '/assets/components/cover-art.css';
+@import '/assets/components/doc/dark-theme-and-light-theme.css';
 @import '/assets/components/detail-card.css';
 @import '/assets/components/detail-section.css';
 @import '/assets/components/embedded-collection-editor.css';

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -23,6 +23,7 @@
 @import '/assets/components/mode-indicator.css';
 @import '/assets/components/next-steps.css';
 @import '/assets/components/pill-button.css';
+@import '/assets/components/progress-icon.css';
 @import '/assets/components/queue-card.css';
 @import '/assets/components/queue.css';
 @import '/assets/components/select-btn.css';

--- a/app/styles/components/doc/dark-theme-and-light-theme.css
+++ b/app/styles/components/doc/dark-theme-and-light-theme.css
@@ -1,0 +1,9 @@
+.doc-dark-theme-and-light-theme {
+  display: flex;
+  flex-direction: row;
+}
+.doc-dark-theme-and-light-theme__container {
+  padding: 20px;
+  border-radius: var(--boxel-border-radius);
+  background-color: var(--boxel-purple-500);
+}

--- a/app/styles/components/progress-icon.css
+++ b/app/styles/components/progress-icon.css
@@ -1,0 +1,29 @@
+.progress-icon {
+  --icon-color: var(--boxel-highlight);
+  position: relative;
+  background-image: url('/media-registry/progress-pie/progress-circle-dark.svg');
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+
+.boxel--light-theme .progress-icon {
+  background-image: url('/assets/images/icons/progress-circle.svg');
+}
+
+.progress-icon.cancelled {
+  background-image: url('/assets/images/icons/icon-x-circle-ht.svg');
+}
+
+.progress-icon.complete {
+  background-image: url('/assets/images/icons/icon-check-circle-ht.svg');
+}
+
+.progress-icon__progress-pie {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+  stroke-dasharray: 0 60;
+  transition: stroke-dasharray var(--boxel-transition);
+}

--- a/app/styles/components/queue-card.css
+++ b/app/styles/components/queue-card.css
@@ -132,7 +132,7 @@
 
 
 /* Light Theme */
-.queue-card--light-theme {
+.boxel--light-theme {
   --queue-card-primary-color: var(--boxel-dark);
   --queue-card-secondary-color: var(--boxel-purple-400);
   --boxel-highlight: #00B2AE;
@@ -140,14 +140,9 @@
   background-color: var(--boxel-light);
 }
 
-.queue-card--light-theme .queue-card__footer {
+.boxel--light-theme .queue-card__footer {
   border-color: rgba(55, 53, 67, 0.15);
 }
-
-.queue-card--light-theme .queue-card__progress-icon {
-  background-image: url('/assets/images/icons/progress-circle.svg');
-}
-
 
 /* Status */
 .queue-card__status {
@@ -158,36 +153,4 @@
   color: var(--boxel-highlight);
   font-weight: 600;
   letter-spacing: var(--boxel-lsp);
-}
-
-.queue-card__progress-icon {
-  --icon-color: var(--boxel-highlight);
-  position: relative;
-  width: 24px;
-  height: 24px;
-  background-image: url('/media-registry/progress-pie/progress-circle-dark.svg');
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: contain;
-}
-
-.queue-card__progress-icon.cancelled {
-  width: 16px;
-  height: 16px;
-  background-image: url('/assets/images/icons/icon-x-circle-ht.svg');
-}
-
-.queue-card__progress-icon.complete {
-  width: 16px;
-  height: 16px;
-  background-image: url('/assets/images/icons/icon-check-circle-ht.svg');
-}
-
-.queue-card__progress-pie {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  transform: rotate(-90deg);
-  stroke-dasharray: 0 60;
-  transition: stroke-dasharray var(--boxel-transition);
 }


### PR DESCRIPTION
Open question for @burieberry and @mattmcmanus -- how should we handle the naming of the light-theme CSS class? 
I used `boxel--light-theme` but I'm sure that is not the BEM way.

https://user-images.githubusercontent.com/353/104303061-8b495080-5504-11eb-887a-728ce8f23624.mov

![Screen Shot 2021-01-12 at 6 08 18 PM](https://user-images.githubusercontent.com/353/104303068-8edcd780-5504-11eb-9253-fb1c3fd2d850.png)
