### PR TITLE
Missing component namespace and deprecated helper fix

### DIFF
--- a/app/components/cardflow.hbs
+++ b/app/components/cardflow.hbs
@@ -52,7 +52,7 @@
       {{/each}}
 
       {{!-- Reply to message box --}}
-      {{#if (contains @model.user.id @model.thread.participant_ids)}}
+      {{#if (includes @model.user.id @model.thread.participant_ids)}}
         <div class="cardflow__message">
           <div class="cardflow__message-icon__profile" style={{css-url "background-image" @model.user.imgURL}} />
           <Input @class="cardflow__reply-to field-renderer__input" @placeholder="Post a message to this thread"></Input>

--- a/app/components/cards/audio.hbs
+++ b/app/components/cards/audio.hbs
@@ -1,3 +1,3 @@
 <Card @model={{@model}} @mode="view" @status={{@status}} @comparisonType={{@comparisonType}}>
-  <WavePlayer @url="/assets/demo_flac.flac" />
+  <Boxel::WavePlayer @url="/assets/demo_flac.flac" />
 </Card>

--- a/app/components/comparison.hbs
+++ b/app/components/comparison.hbs
@@ -129,7 +129,7 @@
         {{/let}}
 
         {{#each this.compFieldGroup as |compField|}}
-          {{#if (not (contains compField.title this.fieldsNotRendered))}}
+          {{#if (not (includes compField.title this.fieldsNotRendered))}}
             {{#with (find-by 'title' compField.title this.baseFieldGroup) as |field|}}
               <div class="discrepancy-field discrepancy-field--base-field {{compField.title}} {{this.mode}}-view">
 
@@ -220,7 +220,7 @@
                   {{/let}}
                 {{else}}
 
-                  {{#if (and compField.status (eq this.mode "comparison") (not (contains field.title this.omittedFields)))}}
+                  {{#if (and compField.status (eq this.mode "comparison") (not (includes field.title this.omittedFields)))}}
                     {{#if field.tempField}}
                       <div class="discrepancy-field__btn-container discrepancy-field__btn-container--toggled">
                         <IconButton @class="discrepancy-field__btn discrepancy-field__btn--toggled" @icon="carot-thin-left" {{on "click" (fn this.revertField field)}} />

--- a/app/components/comparison.hbs
+++ b/app/components/comparison.hbs
@@ -9,7 +9,7 @@
       {{/let}}
     </header>
 
-    <Breadcrumbs @class="discrepancy__breadcrumbs">
+    <Boxel::Breadcrumbs @class="discrepancy__breadcrumbs">
       <LinkTo @route={{@topLevelRoute}} @model={{if @model.topLevelCard @model.topLevelCard.id @model.id}} @class="breadcrumbs__item breadcrumbs__item--inverse">
         <div class="breadcrumbs__item-label">Field</div>
         <div class="breadcrumbs__item-title">Musical Work</div>
@@ -36,7 +36,7 @@
           <div class="breadcrumbs__item-title">{{humanize @model.cardType}}</div>
         </div>
       {{/if}}
-    </Breadcrumbs>
+    </Boxel::Breadcrumbs>
 
     <div class="discrepancy__main {{if (eq this.mode "comparison") "discrepancy__main--comp-view"}}">
       <div class="discrepancy__comparison-header {{if (eq this.mode "comparison") "discrepancy__comparison-header--comp-mode"}}">

--- a/app/components/field-renderer.hbs
+++ b/app/components/field-renderer.hbs
@@ -140,7 +140,7 @@
             </CardPlatter>
           </Boxel>
         {{else}}
-          {{#if (contains @field.title @omittedFields)}}
+          {{#if (includes @field.title @omittedFields)}}
             N/A
           {{else}}
             <CardPlatter @class="field-renderer__card field-renderer__card--blank" />
@@ -153,17 +153,17 @@
 {{else}}
   {{!-- View Mode --}}
   <Boxel @class="field-renderer field-renderer--{{@field.type}} {{format-id @field.title}}-field {{if (eq @field.format "table") "table-field"}} {{@class}}">
-    {{#if (contains @field.title @addedFields)}}
+    {{#if (includes @field.title @addedFields)}}
       <BoxelHighlight @status="added" />
       <BoxelActions @status="added" />
     {{/if}}
     <div class="field-renderer__title">{{humanize @field.title}}</div>
     <Boxel @class="field-renderer__value {{if (eq @field.type "image") "field-renderer__value--img-field"}}">
-      {{#if (and @comparisonMode (contains @field.title @addedValues))}}
+      {{#if (and @comparisonMode (includes @field.title @addedValues))}}
         <BoxelHighlight @status="added" />
         <BoxelActions @status="added" />
       {{/if}}
-      {{#if (and @comparisonMode (contains @field.title @modifiedValues))}}
+      {{#if (and @comparisonMode (includes @field.title @modifiedValues))}}
         <BoxelHighlight @status="modified" />
         <BoxelActions @status="modified" />
       {{/if}}

--- a/app/components/isolated-collection-table.hbs
+++ b/app/components/isolated-collection-table.hbs
@@ -59,9 +59,9 @@
                 {{#each cell as |c|}}
                   {{c}}<br>
                 {{/each}}
-              {{else if (contains column.valuePath this.dateFields)}}
+              {{else if (includes column.valuePath this.dateFields)}}
                 {{moment-format cell "MMM DD, YYYY" "YYYY-MM-DD"}}
-              {{else if (contains column.valuePath this.titleCaseFields)}}
+              {{else if (includes column.valuePath this.titleCaseFields)}}
                 {{titleize cell}}
               {{else}}
                 {{cell}}

--- a/app/templates/media-registry/collection.hbs
+++ b/app/templates/media-registry/collection.hbs
@@ -1,5 +1,5 @@
 <div class="collection__wrapper">
-  <Breadcrumbs @items={{array (hash route="media-registry.index" routeModel=@model.currentOrg.id title="Master Recordings" type=@model.type)}} />
+  <Boxel::Breadcrumbs @items={{array (hash route="media-registry.index" routeModel=@model.currentOrg.id title="Master Recordings" type=@model.type)}} />
 
   <IsolatedCollection
     @mode="view"

--- a/app/templates/media-registry/item.hbs
+++ b/app/templates/media-registry/item.hbs
@@ -3,7 +3,7 @@
 {{else}}
   <DetailTemplate>
     {{!-- Breadcrumbs --}}
-    <Breadcrumbs>
+    <Boxel::Breadcrumbs>
       <LinkTo @route="media-registry" @model={{@model.owner_id}} @class="breadcrumbs__item">
         <div class="breadcrumbs__item-label">Collection</div>
         <div class="breadcrumbs__item-title">Master Recordings</div>
@@ -22,7 +22,7 @@
           <div class="breadcrumbs__item-title">{{titleize @model.title}}</div>
         </LinkTo>
       {{/if}}
-    </Breadcrumbs>
+    </Boxel::Breadcrumbs>
 
     {{#if (eq this.target.currentRouteName "media-registry.item.musical-work")}}
       {{outlet}}

--- a/app/templates/media-registry/musical-works/work-version.hbs
+++ b/app/templates/media-registry/musical-works/work-version.hbs
@@ -1,12 +1,12 @@
 <DetailTemplate>
-  <Breadcrumbs>
+  <Boxel::Breadcrumbs>
     {{#if this.work.masterDetail}}
       <LinkTo @route="media-registry.version" @models={{array this.work.masterDetail.id this.work.version}} @class="breadcrumbs__item">
         <div class="breadcrumbs__item-label">Master Detail</div>
         <div class="breadcrumbs__item-title">{{this.work.masterDetail.title}}</div>
       </LinkTo>
     {{/if}}
-  </Breadcrumbs>
+  </Boxel::Breadcrumbs>
 
   <DetailCard
     @headerFields={{this.headerFields}}

--- a/app/templates/media-registry/musical-works/work.hbs
+++ b/app/templates/media-registry/musical-works/work.hbs
@@ -1,12 +1,12 @@
 <DetailTemplate>
-  <Breadcrumbs>
+  <Boxel::Breadcrumbs>
     {{#if this.work.masterDetail}}
       <LinkTo @route="media-registry.item" @model={{this.work.masterDetail.id}} @class="breadcrumbs__item">
         <div class="breadcrumbs__item-label">Master Detail</div>
         <div class="breadcrumbs__item-title">{{this.work.masterDetail.title}}</div>
       </LinkTo>
     {{/if}}
-  </Breadcrumbs>
+  </Boxel::Breadcrumbs>
 
   <DetailCard
     @headerFields={{this.headerFields}}

--- a/app/templates/media-registry/products/album.hbs
+++ b/app/templates/media-registry/products/album.hbs
@@ -1,10 +1,10 @@
 <DetailTemplate>
-  <Breadcrumbs>
+  <Boxel::Breadcrumbs>
     <LinkTo @route="media-registry" @model={{@model.owner_id}} @class="breadcrumbs__item">
       <div class="breadcrumbs__item-label">Collection</div>
       <div class="breadcrumbs__item-title">Master Recordings</div>
     </LinkTo>
-  </Breadcrumbs>
+  </Boxel::Breadcrumbs>
 
   <DetailCard
     @mode="view"

--- a/app/templates/media-registry/version.hbs
+++ b/app/templates/media-registry/version.hbs
@@ -3,12 +3,12 @@
 {{else}}
   <DetailTemplate>
     {{!-- Breadcrumbs --}}
-    <Breadcrumbs>
+    <Boxel::Breadcrumbs>
       <LinkTo @route="media-registry" @model={{@model.owner_id}} @query={{hash version=@model.version}} @class="breadcrumbs__item">
         <div class="breadcrumbs__item-label">Collection</div>
         <div class="breadcrumbs__item-title">Master Recordings</div>
       </LinkTo>
-    </Breadcrumbs>
+    </Boxel::Breadcrumbs>
 
     <MusicDetailCard
       @mode="view"


### PR DESCRIPTION
- Fix missing namespace on breadcrumbs component on collection pages (https://cardstack.github.io/boxel/#/scenarios/media-registry/bunny_records/collections/golden-girl is currently broken)
- Use `includes` instead of `contains` helper, since it seems to be deprecated in ember-composable-helpers