### PR TITLE
Fix css-vars string handling

### DIFF
--- a/app/components/boxel/cover-art/index.hbs
+++ b/app/components/boxel/cover-art/index.hbs
@@ -1,8 +1,8 @@
 <div
   class="cover-art"
   style={{css-var
-    cover-art-width=this.maxWidth
-    cover-art-size=this.size
+    cover-art-width=(concat this.maxWidth 'px')
+    cover-art-size=(concat this.size 'px')
     cover-art-count=(get @covers 'length')
   }}
   ...attributes
@@ -12,8 +12,8 @@
         class="cover-art__container cover-art__container--{{i}}"
         style={{css-var
           cover-art-index=i
-          cover-art-left=(fn this.coverArtLeft i this.coverArtSpacing)
-          cover-art-cover-size=(fn this.coverArtSize i)
+          cover-art-left=(fn this.coverArtLeftPx i this.coverArtSpacing)
+          cover-art-cover-size=(fn this.coverArtSizePx i)
         }}
       >
         <img class="cover-art__cover" src={{art}} alt="cover art" />

--- a/app/components/boxel/cover-art/index.js
+++ b/app/components/boxel/cover-art/index.js
@@ -22,7 +22,16 @@ export default class extends Component {
     return this.size * (0.8**index);
   }
 
+  @action coverArtSizePx(index) {
+    return `${this.coverArtSize(index)}px`;
+  }
+
   @action coverArtLeft(index, spacing) {
     return this.size * 0.8 * index * (0.85**index) * spacing;
   }
+
+  @action coverArtLeftPx(index, spacing) {
+    return `${this.coverArtLeft(index, spacing)}px`;
+  }
+
 }

--- a/app/components/boxel/dropdown-button/index.hbs
+++ b/app/components/boxel/dropdown-button/index.hbs
@@ -4,7 +4,7 @@
     @class
     boxel-dropdown-button--no-hover=@noHoverStyle
   }}
-  style={{css-var dropdown-button-size=(or @size 40)}}
+  style={{css-var dropdown-button-size=(concat (or @size 40) 'px')}}
   ...attributes
 >
   <BasicDropdown @verticalPosition="below" @renderInPlace={{true}} as |dd|>

--- a/app/helpers/css-var.js
+++ b/app/helpers/css-var.js
@@ -5,9 +5,6 @@ function formatValue(value) {
   if (typeof value === 'function') {
     value = value();
   }
-  if (typeof value === 'string') {
-    value = `'${value}'`
-  }
 
   return value;
 }

--- a/app/styles/components/boxel/dropdown-button.css
+++ b/app/styles/components/boxel/dropdown-button.css
@@ -1,10 +1,10 @@
 .boxel-dropdown-button {
-  --dropdown-button-size: 40;
+  --dropdown-button-size: 40px;
 }
 
 .boxel-dropdown-button__trigger {
-  width: calc(var(--dropdown-button-size) * 1px);
-  height: calc(var(--dropdown-button-size) * 1px);
+  width: var(--dropdown-button-size);
+  height: var(--dropdown-button-size);
   padding: 0;
   border: none;
   background: none;

--- a/app/styles/components/cover-art.css
+++ b/app/styles/components/cover-art.css
@@ -1,6 +1,6 @@
 .cover-art {
-  --cover-art-size: 80;
-  --cover-art-max-width: 190;
+  --cover-art-size: 80px;
+  --cover-art-max-width: 190px;
   --cover-art-count: 1;
 
   position: relative;
@@ -9,26 +9,27 @@
   grid-auto-flow: column;
   z-index: 0;
 
-  width: calc(var(--cover-art-max-width) * 1px);
-  height: calc(var(--cover-art-size) * 1px);
+  width: var(--cover-art-max-width);
+  height: var(--cover-art-size);
 }
 
 .cover-art__container {
   --cover-art-index: 0;
-  --cover-art-left: 0;
-  --cover-art-cover-size: 100;
+  --cover-art-left: 0px;
+  --cover-art-cover-size: 100px;
 
-  transition: left 200ms ease-in-out;
+  transition: left 250ms ease-in-out;
 
   position: absolute;
   z-index: calc(var(--cover-art-count) - var(--cover-art-index));
-  left: calc(var(--cover-art-left) * 1px);
+  left: var(--cover-art-left);
 }
 .cover-art__cover {
 
   object-fit: cover;
   object-position: center;
   border: 1px solid rgba(0, 0, 0, 0.15);
-  height: calc(var(--cover-art-cover-size) * 1px);
-  width: calc(var(--cover-art-cover-size) * 1px);
+  height: var(--cover-art-cover-size);
+  width: var(--cover-art-cover-size);
+  transition: height width 150ms ease-in-out;
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-animated-tools": "^0.4.1",
-    "ember-blurhash": "~0.0.5",
     "ember-class-names-helper": "^0.1.0",
     "ember-cli": "~3.17.0",
     "ember-cli-dependency-checker": "^3.1.0",

--- a/tests/unit/helpers/css-var-test.js
+++ b/tests/unit/helpers/css-var-test.js
@@ -6,23 +6,23 @@ module('Unit | Helper | css-var', function(hooks) {
   setupTest(hooks);
 
   test('takes an object and converts it to css variables', function(assert) {
-    assert.equal(cssVar({ foo: 'bar' }), "--foo: 'bar'");
+    assert.equal(cssVar({ foo: 'bar' }), "--foo: bar");
     assert.equal(cssVar({
       foo: 'bar',
       baz: 1
-    }), "--foo: 'bar'; --baz: 1");
+    }), "--foo: bar; --baz: 1");
 
     assert.equal(cssVar({
       'foo-bar': 'baz',
-    }), "--foo-bar: 'baz'");
+    }), "--foo-bar: baz");
 
     assert.equal(cssVar({
       'fooBar': 'baz',
-    }), "--fooBar: 'baz'");
+    }), "--fooBar: baz");
 
     let fun = function() { return 'baz'};
     assert.equal(cssVar({
       'fooBar': fun
-    }), "--fooBar: 'baz'");
+    }), "--fooBar: baz");
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4843,11 +4843,6 @@ blueimp-md5@^2.10.0:
   resolved "https://registry.yarnpkg.com/blueimp-md5/-/blueimp-md5-2.13.0.tgz#07314b0c64dda0bf1733f96ce40d5af94eb28965"
   integrity sha512-lmp0m647R5e77ORduxLW5mISIDcvgJZa52vMBv5uVI3UmSWTQjkJsZVBfaFqQPw/QFogJwvY6e3Gl9nP+Loe+Q==
 
-blurhash@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/blurhash/-/blurhash-1.1.3.tgz#dc325af7da836d07a0861d830bdd63694382483e"
-  integrity sha512-yUhPJvXexbqbyijCIE/T2NCXcj9iNPhWmOKbPTuR/cm7Q5snXYIfnVnz6m7MWOXxODMz/Cr3UcVkRdHiuDVRDw==
-
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
@@ -7603,17 +7598,6 @@ ember-basic-dropdown@^3.0.1:
     ember-maybe-in-element "^0.4.0"
     ember-truth-helpers "2.1.0"
 
-ember-blurhash@~0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/ember-blurhash/-/ember-blurhash-0.0.5.tgz#bec5c54f84b9be3c17a3c264889ed957cdcba2f0"
-  integrity sha512-VeEykIcLnOPo8HtwWQBesqzItFz+K503SOGQW44piAzUBlE1os5cTYWxwbSYrF6qH5JWp+yZFe5dix50484Dsg==
-  dependencies:
-    blurhash "^1.1.3"
-    ember-auto-import "^1.10.1"
-    ember-cli-babel "^7.23.0"
-    ember-cli-htmlbars "^4.2.2"
-    ember-modifier "^2.1.1"
-
 ember-class-names-helper@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/ember-class-names-helper/-/ember-class-names-helper-0.1.0.tgz#38e5adb57e84833c0f135bc5938ee4c56cca1850"
@@ -8597,7 +8581,7 @@ ember-modifier-manager-polyfill@^1.1.0, ember-modifier-manager-polyfill@^1.2.0:
     ember-cli-version-checker "^2.1.2"
     ember-compatibility-helpers "^1.2.0"
 
-ember-modifier@^2.1.0, ember-modifier@^2.1.1:
+ember-modifier@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-2.1.1.tgz#aa3a12e2d6cf1622f774f3f1eab4880982a43fa9"
   integrity sha512-g9mcpFWgw5lgNU40YNf0USNWqoGTJ+EqjDQKjm7556gaRNDeGnLylFKqx9O3opwLHEt6ZODnRDy9U0S5YEMREg==


### PR DESCRIPTION
- quoting strings is not the right behavior for css-vars helper. Desired output is "--var-name: 100px" not "--var-name: '100px'"
- Removed unused addon ember-blurhash