### PR TITLE
Add macro-decorators and use for default component arg values

### DIFF
--- a/app/components/boxel/cover-art/index.js
+++ b/app/components/boxel/cover-art/index.js
@@ -1,14 +1,9 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-
+import { reads } from 'macro-decorators'
 export default class extends Component {
-  get size() {
-    return this.args.size || 80;
-  }
-
-  get maxWidth() {
-    return this.args.maxWidth || 190;
-  }
+  @reads('args.size', 80) size;
+  @reads('args.maxWidth', 190) maxWidth;
 
   get coverArtSpacing() {
     let { maxWidth, args: { covers }} = this;

--- a/app/components/boxel/progress-circle/index.js
+++ b/app/components/boxel/progress-circle/index.js
@@ -1,10 +1,11 @@
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
+import { reads } from 'macro-decorators';
 
 const FONT_SIZE_RATIO = 25/120;
 
 export default class extends Component {
-  @tracked size = this.args.size ? this.args.size : 120;
+  @reads('args.size', 120) size;
+
   get fontSize() {
     return this.size * FONT_SIZE_RATIO;
   }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-animated-tools": "^0.4.1",
+    "ember-auto-import": "^1.10.1",
     "ember-blurhash": "~0.0.5",
     "ember-class-names-helper": "^0.1.0",
     "ember-cli": "~3.17.0",
@@ -79,6 +80,7 @@
     "eslint-plugin-ember": "^8.1.1",
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "^4.7.0",
+    "macro-decorators": "^0.1.2",
     "qunit-dom": "^1.1.0",
     "release-it": "^13.5.1",
     "release-it-lerna-changelog": "^2.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12264,6 +12264,11 @@ macos-release@^2.2.0:
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
   integrity sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==
 
+macro-decorators@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/macro-decorators/-/macro-decorators-0.1.2.tgz#1d5cf1276d343371040af192901947f2a0af03c1"
+  integrity sha512-BV5XPmCm9kPSMtgfZiv0vTjOooe5pTIPIVkdoqbC49H1B7z22KB39H50R2ZNclZDQlmVyviLozRatKnOYZkwzg==
+
 magic-string@^0.24.0:
   version "0.24.1"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.24.1.tgz#7e38e5f126cae9f15e71f0cf8e450818ca7d5a8f"


### PR DESCRIPTION
Note: this PR is against #252 not master

@burieberry the missing piece was ember-auto-import, necessary because this is a plain old javascript library and not an ember addon