### PR TITLE
Refactor progress circle

### DIFF
--- a/app/components/boxel/progress-circle/index.css
+++ b/app/components/boxel/progress-circle/index.css
@@ -1,5 +1,4 @@
 .progress-circle {
-  --icon-color: var(--boxel-highlight);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -13,6 +12,16 @@
   width: 100%;
   height: 100%;
   transform: rotate(-90deg);
+}
+
+.progress-circle__background-circle { 
+  stroke: var(--boxel-light-400);
+  fill: none;
+}
+
+.progress-circle__indicator-circle {
+  stroke: var(--boxel-highlight);
+  fill: none;
   stroke-dasharray: 0 360;
   transition: stroke-dasharray var(--boxel-transition);
 }

--- a/app/components/boxel/progress-circle/index.css
+++ b/app/components/boxel/progress-circle/index.css
@@ -5,9 +5,6 @@
   justify-content: center;
   position: relative;
   margin: 0 auto;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: contain;
 }
 
 .progress-circle__pie {

--- a/app/components/boxel/progress-circle/index.css
+++ b/app/components/boxel/progress-circle/index.css
@@ -1,4 +1,6 @@
 .progress-circle {
+  --progress-arc-color: var(--boxel-highlight);
+  --progress-arc-background-color: var(--boxel-light-400);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -15,15 +17,15 @@
 }
 
 .progress-circle__background-circle { 
-  stroke: var(--boxel-light-400);
+  stroke: var(--progress-arc-background-color);
   fill: none;
 }
 
 .progress-circle__indicator-circle {
-  stroke: var(--boxel-highlight);
+  stroke: var(--progress-arc-color);
   fill: none;
-  stroke-dasharray: 0 360;
-  transition: stroke-dasharray var(--boxel-transition);
+  stroke-dasharray: 0 360; /* Note: this is overridden by an inline style to show a progress arc of the right length */
+  transition: stroke-dasharray var(--boxel-transition); 
 }
 
 .progress-circle__pct-label {

--- a/app/components/boxel/progress-circle/index.css
+++ b/app/components/boxel/progress-circle/index.css
@@ -5,7 +5,6 @@
   justify-content: center;
   position: relative;
   margin: 0 auto;
-  background-image: url('../../../images/icons/progress-circle-lg.svg');
   background-position: center;
   background-repeat: no-repeat;
   background-size: contain;

--- a/app/components/boxel/progress-circle/index.hbs
+++ b/app/components/boxel/progress-circle/index.hbs
@@ -7,7 +7,12 @@
     class="progress-circle__pie"
     style={{html-safe (concat "stroke-dasharray:" (mult (div @percentComplete 100) 339) " " 339)}}
   >
-    {{svg-jar "progress-circle-lg" width=this.size height=this.size}}
+    <svg xmlns="http://www.w3.org/2000/svg" width={{this.size}} height={{this.size}} viewBox="0 0 120 120">
+      <g fill="none" stroke="var(--icon-color, #e8e8e8)" stroke-width="12">
+        <circle cx="60" cy="60" r="60" stroke="none"/>
+        <circle cx="60" cy="60" r="54" fill="none"/>
+      </g>
+    </svg>
   </div>
   <div
     class="progress-circle__pct-label"

--- a/app/components/boxel/progress-circle/index.hbs
+++ b/app/components/boxel/progress-circle/index.hbs
@@ -13,6 +13,13 @@
           cy={{this.outerCircleRadius}}  
           r={{this.strokeCircleRadius}} 
           fill="none" 
+          style="stroke-dasharray: 339; stroke: #e8e8e8;"
+        />
+        <circle 
+          cx={{this.outerCircleRadius}} 
+          cy={{this.outerCircleRadius}}  
+          r={{this.strokeCircleRadius}} 
+          fill="none" 
           style={{html-safe (concat "stroke-dasharray:" (mult (div @percentComplete 100) 339) " " 339)}}
         />
       </g>

--- a/app/components/boxel/progress-circle/index.hbs
+++ b/app/components/boxel/progress-circle/index.hbs
@@ -7,7 +7,7 @@
     class="progress-circle__pie"
   >
     <svg xmlns="http://www.w3.org/2000/svg" width={{this.size}} height={{this.size}} viewBox="0 0 {{this.outerCircleDiameter}} {{this.outerCircleDiameter}}">
-      <g fill="none" stroke="var(--icon-color, #e8e8e8)" stroke-width="12">
+      <g fill="none" stroke="var(--icon-color, #e8e8e8)" stroke-width="{{this.progressArcThickness}}">
         <circle 
           cx={{this.outerCircleRadius}} 
           cy={{this.outerCircleRadius}}  

--- a/app/components/boxel/progress-circle/index.hbs
+++ b/app/components/boxel/progress-circle/index.hbs
@@ -6,11 +6,11 @@
   <div
     class="progress-circle__pie"
   >
-    <svg xmlns="http://www.w3.org/2000/svg" width={{this.size}} height={{this.size}} viewBox="0 0 120 120">
+    <svg xmlns="http://www.w3.org/2000/svg" width={{this.size}} height={{this.size}} viewBox="0 0 {{this.outerCircleDiameter}} {{this.outerCircleDiameter}}">
       <g fill="none" stroke="var(--icon-color, #e8e8e8)" stroke-width="12">
         <circle 
-          cx="60" 
-          cy="60" 
+          cx={{this.outerCircleRadius}} 
+          cy={{this.outerCircleRadius}}  
           r="54" 
           fill="none" 
           style={{html-safe (concat "stroke-dasharray:" (mult (div @percentComplete 100) 339) " " 339)}}

--- a/app/components/boxel/progress-circle/index.hbs
+++ b/app/components/boxel/progress-circle/index.hbs
@@ -5,12 +5,17 @@
 >
   <div
     class="progress-circle__pie"
-    style={{html-safe (concat "stroke-dasharray:" (mult (div @percentComplete 100) 339) " " 339)}}
   >
     <svg xmlns="http://www.w3.org/2000/svg" width={{this.size}} height={{this.size}} viewBox="0 0 120 120">
       <g fill="none" stroke="var(--icon-color, #e8e8e8)" stroke-width="12">
         <circle cx="60" cy="60" r="60" stroke="none"/>
-        <circle cx="60" cy="60" r="54" fill="none"/>
+        <circle 
+          cx="60" 
+          cy="60" 
+          r="54" 
+          fill="none" 
+          style={{html-safe (concat "stroke-dasharray:" (mult (div @percentComplete 100) 339) " " 339)}}
+        />
       </g>
     </svg>
   </div>

--- a/app/components/boxel/progress-circle/index.hbs
+++ b/app/components/boxel/progress-circle/index.hbs
@@ -20,7 +20,7 @@
           cy={{this.outerCircleRadius}}  
           r={{this.strokeCircleRadius}} 
           fill="none" 
-          style={{html-safe (concat "stroke-dasharray:" (mult (div @percentComplete 100) 339) " " 339)}}
+          style={{this.pieStyle}}
         />
       </g>
     </svg>

--- a/app/components/boxel/progress-circle/index.hbs
+++ b/app/components/boxel/progress-circle/index.hbs
@@ -8,7 +8,6 @@
   >
     <svg xmlns="http://www.w3.org/2000/svg" width={{this.size}} height={{this.size}} viewBox="0 0 120 120">
       <g fill="none" stroke="var(--icon-color, #e8e8e8)" stroke-width="12">
-        <circle cx="60" cy="60" r="60" stroke="none"/>
         <circle 
           cx="60" 
           cy="60" 

--- a/app/components/boxel/progress-circle/index.hbs
+++ b/app/components/boxel/progress-circle/index.hbs
@@ -20,7 +20,7 @@
   </div>
   <div
     class="progress-circle__pct-label"
-    style={{html-safe (concat "font-size:" this.fontSize "px;width:" this.innerCircleSize "px; height:" this.innerCircleSize "px;")}}
+    style={{html-safe (concat "font-size:" this.fontSize "px;width:" this.percentLabelDiameter "px; height:" this.percentLabelDiameter "px;")}}
   >
     {{this.humanPercentComplete}}%
   </div>

--- a/app/components/boxel/progress-circle/index.hbs
+++ b/app/components/boxel/progress-circle/index.hbs
@@ -7,19 +7,18 @@
     class="progress-circle__pie"
   >
     <svg xmlns="http://www.w3.org/2000/svg" width={{this.size}} height={{this.size}} viewBox="0 0 {{this.outerCircleDiameter}} {{this.outerCircleDiameter}}">
-      <g fill="none" stroke="var(--icon-color, #e8e8e8)" stroke-width="{{this.progressArcThickness}}">
+      <g stroke-width="{{this.progressArcThickness}}">
         <circle 
           cx={{this.outerCircleRadius}} 
           cy={{this.outerCircleRadius}}  
           r={{this.strokeCircleRadius}} 
-          fill="none" 
-          style="stroke-dasharray: 339; stroke: #e8e8e8;"
+          class="progress-circle__background-circle"
         />
         <circle 
           cx={{this.outerCircleRadius}} 
           cy={{this.outerCircleRadius}}  
           r={{this.strokeCircleRadius}} 
-          fill="none" 
+          class="progress-circle__indicator-circle"
           style={{this.pieStyle}}
         />
       </g>

--- a/app/components/boxel/progress-circle/index.hbs
+++ b/app/components/boxel/progress-circle/index.hbs
@@ -11,7 +11,7 @@
         <circle 
           cx={{this.outerCircleRadius}} 
           cy={{this.outerCircleRadius}}  
-          r="54" 
+          r={{this.strokeCircleRadius}} 
           fill="none" 
           style={{html-safe (concat "stroke-dasharray:" (mult (div @percentComplete 100) 339) " " 339)}}
         />

--- a/app/components/boxel/progress-circle/index.js
+++ b/app/components/boxel/progress-circle/index.js
@@ -4,6 +4,7 @@ import { reads } from 'macro-decorators';
 const FONT_SIZE_RATIO = 25 / 120;
 
 export default class extends Component {
+  progressArcThickness = 12;
   outerCircleRadius = 60;
   outerCircleDiameter = this.outerCircleRadius * 2;
   @reads('args.size', 120) size;

--- a/app/components/boxel/progress-circle/index.js
+++ b/app/components/boxel/progress-circle/index.js
@@ -4,6 +4,8 @@ import { reads } from 'macro-decorators';
 const FONT_SIZE_RATIO = 25 / 120;
 
 export default class extends Component {
+  outerCircleRadius = 60;
+  outerCircleDiameter = this.outerCircleRadius * 2;
   @reads('args.size', 120) size;
 
   get fontSize() {

--- a/app/components/boxel/progress-circle/index.js
+++ b/app/components/boxel/progress-circle/index.js
@@ -14,8 +14,11 @@ export default class extends Component {
   get fontSize() {
     return this.size * FONT_SIZE_RATIO;
   }
-  get innerCircleSize() {
-    return this.size - this.fontSize;
+  get scale() {
+    return this.size / this.outerCircleDiameter;
+  }
+  get percentLabelDiameter() {
+    return this.scale * this.innerCircleDiameter
   }
   get humanPercentComplete() {
     if (this.args.percentComplete) {

--- a/app/components/boxel/progress-circle/index.js
+++ b/app/components/boxel/progress-circle/index.js
@@ -6,7 +6,9 @@ const FONT_SIZE_RATIO = 25 / 120;
 export default class extends Component {
   progressArcThickness = 12;
   outerCircleRadius = 60;
+  innerCircleRadius = this.outerCircleRadius - this.progressArcThickness;
   outerCircleDiameter = this.outerCircleRadius * 2;
+  innerCircleDiameter = this.innerCircleRadius * 2;
   @reads('args.size', 120) size;
 
   get fontSize() {

--- a/app/components/boxel/progress-circle/index.js
+++ b/app/components/boxel/progress-circle/index.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { reads } from 'macro-decorators';
+import { htmlSafe } from '@ember/template';
 
 const FONT_SIZE_RATIO = 25 / 120;
 
@@ -10,8 +11,17 @@ export default class extends Component {
   strokeCircleRadius = (this.outerCircleRadius + this.innerCircleRadius) / 2;
   outerCircleDiameter = this.outerCircleRadius * 2;
   innerCircleDiameter = this.innerCircleRadius * 2;
+  strokeCircleCircumference = this.strokeCircleRadius * 2 * Math.PI;
   @reads('args.size', 120) size;
 
+  get pieStyle() {
+    return htmlSafe(
+      `stroke-dasharray: ${this.progressArcLength} ${this.strokeCircleCircumference}`
+    );
+  }
+  get progressArcLength() {
+    return (this.args.percentComplete / 100) * this.strokeCircleCircumference;
+  }
   get fontSize() {
     return this.size * FONT_SIZE_RATIO;
   }

--- a/app/components/boxel/progress-circle/index.js
+++ b/app/components/boxel/progress-circle/index.js
@@ -7,6 +7,7 @@ export default class extends Component {
   progressArcThickness = 12;
   outerCircleRadius = 60;
   innerCircleRadius = this.outerCircleRadius - this.progressArcThickness;
+  strokeCircleRadius = (this.outerCircleRadius + this.innerCircleRadius) / 2;
   outerCircleDiameter = this.outerCircleRadius * 2;
   innerCircleDiameter = this.innerCircleRadius * 2;
   @reads('args.size', 120) size;
@@ -18,7 +19,7 @@ export default class extends Component {
     return this.size / this.outerCircleDiameter;
   }
   get percentLabelDiameter() {
-    return this.scale * this.innerCircleDiameter
+    return this.scale * this.innerCircleDiameter;
   }
   get humanPercentComplete() {
     if (this.args.percentComplete) {

--- a/app/components/boxel/progress-circle/index.js
+++ b/app/components/boxel/progress-circle/index.js
@@ -1,9 +1,6 @@
 import Component from '@glimmer/component';
-import { reads } from 'macro-decorators';
+import { or } from 'macro-decorators';
 import { htmlSafe } from '@ember/template';
-
-const FONT_SIZE_RATIO = 25 / 120;
-
 export default class extends Component {
   progressArcThickness = 12;
   outerCircleRadius = 60;
@@ -12,7 +9,7 @@ export default class extends Component {
   outerCircleDiameter = this.outerCircleRadius * 2;
   innerCircleDiameter = this.innerCircleRadius * 2;
   strokeCircleCircumference = this.strokeCircleRadius * 2 * Math.PI;
-  @reads('args.size', 120) size;
+  @or('args.size', 'outerCircleDiameter') size;
 
   get pieStyle() {
     return htmlSafe(
@@ -22,11 +19,11 @@ export default class extends Component {
   get progressArcLength() {
     return (this.args.percentComplete / 100) * this.strokeCircleCircumference;
   }
-  get fontSize() {
-    return this.size * FONT_SIZE_RATIO;
-  }
   get scale() {
     return this.size / this.outerCircleDiameter;
+  }
+  get fontSize() {
+    return this.scale * 25;
   }
   get percentLabelDiameter() {
     return this.scale * this.innerCircleDiameter;


### PR DESCRIPTION
CS-178

**Why?**
Previous component was rendering HTML based on variables within component, and geometry from an SVG file 'imported' by `svg-jar`. This produced two sources of truth that could conflict if geometry/variables changed on either side

**How?**
Extract two important variables that determine the circle's geometry - `outerCircleRadius`, and `progressArcThickness`, then define other variables based on those. Programmatically generate the svg, rather than 'importing' it, so that both svg and surrounding html are consistent with each other.

**Diagram of variables**
![Screenshot from 2021-02-09 13-24-06](https://user-images.githubusercontent.com/39579264/107319709-523bd600-6ada-11eb-986d-e62d8f126d92.png)

**Before**
https://user-images.githubusercontent.com/39579264/107321430-764ce680-6add-11eb-8e1d-93b40f6aad4c.mp4


**After**
https://user-images.githubusercontent.com/39579264/107321442-7cdb5e00-6add-11eb-949f-49a247fa2172.mp4


