### PR TITLE
change mode-indicator font declaration

### DIFF
--- a/addon/components/boxel/mode-indicator/index.css
+++ b/addon/components/boxel/mode-indicator/index.css
@@ -21,8 +21,7 @@
   border: none;
   border-radius: 100px;
   color: var(--boxel-dark);
-  font: var(--boxel-font-sm);
-  font-weight: 600;
+  font: 600 var(--boxel-font-sm);
   letter-spacing: var(--boxel-lsp-lg);
   text-align: left;
   text-transform: capitalize;


### PR DESCRIPTION
Minifier was stripping a second font-related declaration and so the wrong font weight was displayed. This merges the font weight declaration into the font declaration, which should preserve it when going through minification.