### PR TITLE
Enhancement/linkto support

### DIFF
--- a/addon/components/boxel/button/index.css
+++ b/addon/components/boxel/button/index.css
@@ -29,14 +29,19 @@
 }
 
 /* select disabled buttons and links that don't have href */
-.boxel-button:disabled, a.boxel-button:not([href]),a.boxel-button[href=""] {
+/* 
+  a.boxel-button--disabled-link is a special case for an automatically appended class by the LinkTo component 
+  the LinkTo component appends the href regardless, so we have to select it in other ways.
+  Removing the chained classes will make kind-variants overwrite the disabled style on the LinkTo (specificity issues)
+*/
+.boxel-button:disabled, a.boxel-button:not([href]),a.boxel-button[href=""], a.boxel-button.boxel-button--disabled-link {
   --boxel-button-color: var(--boxel-purple-300);
   --boxel-button-border: 1px solid var(--boxel-purple-300);
   --boxel-button-text-color: var(--boxel-purple-400);
 }
 
 /* the a element does not have a disabled attribute. Clicking will still trigger event listeners */
-a.boxel-button:not([href]),a.boxel-button[href=""] {
+a.boxel-button:not([href]),a.boxel-button[href=""], a.boxel-button.boxel-button--disabled-link {
   pointer-events: none;
 }
 

--- a/addon/components/boxel/button/index.css
+++ b/addon/components/boxel/button/index.css
@@ -28,8 +28,19 @@
   letter-spacing: var(--boxel-button-letter-spacing, var(--boxel-lsp-lg));
 }
 
-.boxel-button:disabled {
+/* select disabled buttons and links that don't have href */
+.boxel-button:disabled, a.boxel-button:not([href]),a.boxel-button[href=""] {
   --boxel-button-color: var(--boxel-purple-300);
   --boxel-button-border: 1px solid var(--boxel-purple-300);
   --boxel-button-text-color: var(--boxel-purple-400);
+}
+
+/* the a element does not have a disabled attribute. Clicking will still trigger event listeners */
+a.boxel-button:not([href]),a.boxel-button[href=""] {
+  pointer-events: none;
+}
+
+/* overwrite the global style for links in global.css */
+a.boxel-button:hover {
+  color: var(--boxel-button-text-color);
 }

--- a/addon/components/boxel/button/index.hbs
+++ b/addon/components/boxel/button/index.hbs
@@ -1,3 +1,17 @@
+{{#if @href}}
+<a
+  class={{cn
+    "boxel-button"
+    (concat "boxel-button--size-" (or @size this.defaultSize))
+    (concat "boxel-button--kind-" (or @kind this.defaultKind))
+  }} 
+  href={{unless @disabled @href}}
+  data-test-boxel-button 
+  ...attributes
+>
+  {{yield}}
+</a>
+{{else}}
 <button
   class={{cn
     "boxel-button"
@@ -10,3 +24,4 @@
 >
   {{yield}}
 </button>
+{{/if}}

--- a/addon/components/boxel/button/index.hbs
+++ b/addon/components/boxel/button/index.hbs
@@ -1,27 +1,39 @@
-{{#if @href}}
-<a
-  class={{cn
+{{#let (cn
     "boxel-button"
     (concat "boxel-button--size-" (or @size this.defaultSize))
     (concat "boxel-button--kind-" (or @kind this.defaultKind))
-  }} 
-  href={{unless @disabled @href}}
-  data-test-boxel-button 
-  ...attributes
->
-  {{yield}}
-</a>
-{{else}}
-<button
-  class={{cn
-    "boxel-button"
-    (concat "boxel-button--size-" (or @size this.defaultSize))
-    (concat "boxel-button--kind-" (or @kind this.defaultKind))
-  }}
-  disabled={{@disabled}}
-  data-test-boxel-button
-  ...attributes
->
-  {{yield}}
-</button>
+ ) as |classes|}}
+{{#if (or (not @as) (eq @as "button"))}}
+  <button
+    class={{classes}}
+    disabled={{@disabled}}
+    data-test-boxel-button
+    ...attributes
+  >
+    {{yield}}
+  </button>
+{{else if (eq @as "anchor")}}
+  <a
+    class={{classes}}
+    href={{unless @disabled @href}}
+    data-test-boxel-button 
+    ...attributes
+  >
+    {{yield}}
+  </a>
+{{else if (eq @as "link-to")}}
+  <LinkTo
+    class={{classes}}
+    @route={{@route}}
+    @models={{if @models @models (array)}}
+    @query={{@query}}
+    @disabled={{@disabled}}
+    @disabledClass="boxel-button--disabled-link"
+    data-test-boxel-button 
+    tabindex={{if @disabled -1 0}}
+    ...attributes
+  >
+    {{yield}}
+  </LinkTo>
 {{/if}}
+{{/let}}

--- a/addon/components/boxel/button/usage.css
+++ b/addon/components/boxel/button/usage.css
@@ -1,4 +1,30 @@
+.usage-button-container {
+  display: flex;
+  flex-wrap: wrap;
+}
+
 .usage-button-dark-mode-background {
   background-color: #413e4e;
   padding: 4px;
+}
+
+.usage-button-explanation {
+  border: 1px solid black;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+.usage-button-explanation td {
+  border: 1px solid black;
+  padding: .25rem;
+}
+
+.usage-button-centers-component {
+  flex-basis: 0;
+  flex-grow: 99;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100%;
+  padding: 2rem;
 }

--- a/addon/components/boxel/button/usage.hbs
+++ b/addon/components/boxel/button/usage.hbs
@@ -1,6 +1,16 @@
 <Freestyle::Usage @name="Button">
   <:example>
     <div class={{cn usage-button-dark-mode-background=(eq this.kind "secondary-dark")}}>
+      {{#if this.href}}
+      <Boxel::Button
+        @kind={{this.kind}}
+        @size={{this.size}}
+        @disabled={{this.disabled}}
+        @href={{this.href}}
+      >
+        Button Text
+      </Boxel::Button>
+      {{else}}
       <Boxel::Button
         @kind={{this.kind}}
         @size={{this.size}}
@@ -10,6 +20,7 @@
       >
         Button Text
       </Boxel::Button>
+      {{/if}}
     </div>
   </:example>
   <:api as |Args|>

--- a/addon/components/boxel/button/usage.hbs
+++ b/addon/components/boxel/button/usage.hbs
@@ -1,4 +1,4 @@
-<Freestyle::Usage @name="Plain Button">
+<Freestyle::Usage @name="Button">
   <:description>
   Depending on the value of `@as`, the button will accept different arguments.
       <table class="usage-button-explanation">
@@ -101,8 +101,8 @@
       @value={{this.route}}
     />
     <Args.Object
-      @name="model"
-      @description="The model argument for LinkTo"
+      @name="models"
+      @description="The models argument for LinkTo"
       @optional={{true}}
       @defaultValue="[]"
     />
@@ -145,4 +145,21 @@
     />
     <Args.Yield @description="Contents of the button" />
   </:api>
+</Freestyle::Usage>
+
+<Freestyle::Usage @name="LinkTo button" @description="This button links you to the media registry page">
+  <:example>
+    <div class={{cn "usage-button-centers-component" usage-button-dark-mode-background=(eq this.kind "secondary-dark")}}>
+      <Boxel::Button
+        @as="link-to"
+        @kind="primary"
+        @size="base"
+        @route="media-registry"
+        @models={{array "bunny_records"}}
+        @query=""
+      >
+        Button Text
+      </Boxel::Button>
+    </div>
+  </:example>
 </Freestyle::Usage>

--- a/addon/components/boxel/button/usage.hbs
+++ b/addon/components/boxel/button/usage.hbs
@@ -5,6 +5,7 @@
         @kind={{this.kind}}
         @size={{this.size}}
         @disabled={{this.disabled}}
+        @href={{this.href}}
         {{on "click" this.alert}}
       >
         Button Text
@@ -12,6 +13,13 @@
     </div>
   </:example>
   <:api as |Args|>
+    <Args.String
+      @name="href"
+      @optional={{true}}
+      @description="A route that the button can lead to. If used, an anchor element is used instead of a button. Note that for accessibility purposes, you should be careful about adding aria/other attributes to a disabled link."
+      @onInput={{fn (mut this.href)}}
+      @value={{this.href}}
+    />
     <Args.String
       @name="kind"
       @optional={{true}}

--- a/addon/components/boxel/button/usage.hbs
+++ b/addon/components/boxel/button/usage.hbs
@@ -1,32 +1,120 @@
-<Freestyle::Usage @name="Button">
+<Freestyle::Usage @name="Plain Button">
+  <:description>
+  Depending on the value of `@as`, the button will accept different arguments.
+      <table class="usage-button-explanation">
+      <tbody>
+        <tr>
+        <td>
+          <code>
+            @as
+          </code>
+        </td>
+        <td>
+          Accepted arguments
+        </td>
+        <td>
+          Used for
+        </td>
+      </tr>
+      <tr>
+        <td>
+          button
+        </td>
+        <td>
+          <ul>
+            <li><code>@size</code></li>
+            <li><code>@kind</code></li>
+            <li><code>@disabled</code></li>
+          </ul>
+        </td>
+        <td>
+          Actions
+        </td>
+      </tr>
+        <tr>
+        <td>
+          anchor
+        </td>
+        <td>
+          <ul>
+            <li><code>@size</code></li>
+            <li><code>@kind</code></li>
+            <li><code>@disabled</code></li>
+            <li><code>@href</code></li>
+          </ul>
+        </td>
+        <td>
+          Any navigation, eg. external CTA
+        </td>
+      </tr>
+      <tr>
+        <td>
+          link-to
+        </td>
+        <td>
+          <ul>
+            <li><code>@size</code></li>
+            <li><code>@kind</code></li>
+            <li><code>@disabled</code></li>
+            <li><code>@route</code></li>
+            <li><code>@models</code></li>
+            <li><code>@query</code></li>
+          </ul>
+          <br>
+          <code>@route, @models,</code> and <code>@query</code> are passed to <code>LinkTo</code> directly
+        </td>
+        <td>
+          Navigation within the app
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </:description>
   <:example>
-    <div class={{cn usage-button-dark-mode-background=(eq this.kind "secondary-dark")}}>
-      {{#if this.href}}
+    <div class={{cn "usage-button-centers-component" usage-button-dark-mode-background=(eq this.kind "secondary-dark")}}>
       <Boxel::Button
+        @as={{this.as}}
         @kind={{this.kind}}
         @size={{this.size}}
         @disabled={{this.disabled}}
         @href={{this.href}}
+        @route={{this.route}}
       >
         Button Text
       </Boxel::Button>
-      {{else}}
-      <Boxel::Button
-        @kind={{this.kind}}
-        @size={{this.size}}
-        @disabled={{this.disabled}}
-        {{on "click" this.alert}}
-      >
-        Button Text
-      </Boxel::Button>
-      {{/if}}
     </div>
   </:example>
   <:api as |Args|>
     <Args.String
+      @name="as"
+      @optional={{true}}
+      @value={{this.as}}
+      @options={{array "button" "anchor" "link-to"}}
+      @description="Determines the component/tag that is used to render the element. `button` renders a `button`, `anchor` renders an `a`, and `link-to` renders a `LinkTo`. Note that for accessibility purposes, you should be careful about adding aria/other attributes to a disabled link."
+      @onInput={{fn (mut this.as)}}
+    />
+    <Args.String
+      @name="route"
+      @optional={{true}}
+      @description="The route argument for LinkTo"
+      @onInput={{fn (mut this.route)}}
+      @value={{this.route}}
+    />
+    <Args.Object
+      @name="model"
+      @description="The model argument for LinkTo"
+      @optional={{true}}
+      @defaultValue="[]"
+    />
+    <Args.String
+      @name="query"
+      @description="The query argument for LinkTo"
+      @optional={{true}}
+    />
+    <Args.String
       @name="href"
       @optional={{true}}
-      @description="A route that the button can lead to. If used, an anchor element is used instead of a button. Note that for accessibility purposes, you should be careful about adding aria/other attributes to a disabled link."
+      @description="A url that the button can lead to."
       @onInput={{fn (mut this.href)}}
       @value={{this.href}}
     />
@@ -57,58 +145,4 @@
     />
     <Args.Yield @description="Contents of the button" />
   </:api>
-</Freestyle::Usage>
-<Freestyle::Usage @name="Button" @description="Light mode">
-  <:example>
-    <table>
-      <tbody>
-        {{#each this.sizeVariants as |size|}}
-          <tr>
-            {{#each this.kindVariants.light as |kind|}}
-              <td>
-                <Boxel::Button @kind={{kind}} @size={{size}}>
-                  {{kind}}
-                </Boxel::Button>
-              </td>
-            {{/each}}
-            <td>
-              <Boxel::Button
-                @size={{size}}
-                @disabled={{true}}
-              >
-                disabled
-              </Boxel::Button>
-            </td>
-          </tr>
-        {{/each}}
-      </tbody>
-    </table>
-  </:example>
-</Freestyle::Usage>
-<Freestyle::Usage @name="Button" @description="Dark mode">
-  <:example>
-    <table class="usage-button-dark-mode-background">
-      <tbody>
-        {{#each this.sizeVariants as |size|}}
-          <tr>
-            {{#each this.kindVariants.dark as |kind|}}
-              <td>
-                <Boxel::Button @kind={{kind}} @size={{size}}>
-                  {{kind}}
-                </Boxel::Button>
-              </td>
-            {{/each}}
-            <td>
-              <Boxel::Button
-                @size={{size}}
-                @disabled={{true}}
-              >
-                disabled
-              </Boxel::Button>
-            </td>
-          </tr>
-        {{/each}}
-      </tbody>
-    </table>
-  </:example>
 </Freestyle::Usage>

--- a/addon/components/boxel/button/usage.hbs
+++ b/addon/components/boxel/button/usage.hbs
@@ -15,7 +15,6 @@
         @kind={{this.kind}}
         @size={{this.size}}
         @disabled={{this.disabled}}
-        @href={{this.href}}
         {{on "click" this.alert}}
       >
         Button Text

--- a/addon/components/boxel/button/usage.ts
+++ b/addon/components/boxel/button/usage.ts
@@ -10,10 +10,18 @@ export default class extends Component {
     dark: ['primary', 'secondary-dark'],
   };
 
+  // base button arguments
+  @tracked as = 'button';
   @tracked size = 'base';
   @tracked kind = 'primary';
   @tracked disabled = false;
+
+  // for @as === 'anchor'
   @tracked href = '#';
+
+  // for @as === 'link-to'
+  @tracked route = 'docs.index';
+  // @model and @query seem hard to use here so leaving them aside for now
 
   @action
   alert(): void {

--- a/addon/components/boxel/button/usage.ts
+++ b/addon/components/boxel/button/usage.ts
@@ -13,6 +13,7 @@ export default class extends Component {
   @tracked size = 'base';
   @tracked kind = 'primary';
   @tracked disabled = false;
+  @tracked href = '#';
 
   @action
   alert(): void {

--- a/tests/integration/components/boxel/button-test.js
+++ b/tests/integration/components/boxel/button-test.js
@@ -26,7 +26,7 @@ module('Integration | Component | Button', function (hooks) {
       clicked = true;
     });
     await render(
-      hbs`<Boxel::Button {{ on 'click' this.onClick}}>A button</Boxel::Button>`
+      hbs`<Boxel::Button {{ on "click" this.onClick }}>A button</Boxel::Button>`
     );
     await click(BUTTON_SELECTOR);
     assert.equal(clicked, true);
@@ -39,7 +39,7 @@ module('Integration | Component | Button', function (hooks) {
 
   test('It can be disabled via argument', async function (assert) {
     await render(
-      hbs`<Boxel::Button @disabled={{true}}>A button</Boxel::Button>`
+      hbs`<Boxel::Button @disabled={{ true }}>A button</Boxel::Button>`
     );
     assert.dom(BUTTON_SELECTOR).isDisabled();
   });
@@ -53,7 +53,7 @@ module('Integration | Component | Button', function (hooks) {
     });
 
     await render(
-      hbs`<Boxel::Button @kind={{this.kind}}>
+      hbs`<Boxel::Button @kind={{ this.kind }}>
           A button
           </Boxel::Button>`
     );
@@ -82,7 +82,7 @@ module('Integration | Component | Button', function (hooks) {
     });
 
     await render(
-      hbs`<Boxel::Button @size={{this.size}}>
+      hbs`<Boxel::Button @size={{ this.size }}>
           A button
           </Boxel::Button>`
     );
@@ -101,4 +101,35 @@ module('Integration | Component | Button', function (hooks) {
     this.set('size', '');
     assert.dom(BUTTON_SELECTOR).hasClass(/--size-base/);
   });
+
+  test('It can render an anchor element with the correct href if there is a href argument and a button otherwise', async function (assert) {
+    this.set('href', '#');
+    await render(
+      hbs`<Boxel::Button @href={{ this.href }}>
+          This should be an anchor
+          </Boxel::Button>`
+    );
+    assert.dom(`a${BUTTON_SELECTOR}`).hasAttribute('href', '#');
+    assert.dom(`button${BUTTON_SELECTOR}`).doesNotExist();
+    this.set('href', '');
+    assert.dom(`a${BUTTON_SELECTOR}`).doesNotExist();
+    assert.dom(`button${BUTTON_SELECTOR}`).doesNotHaveAttribute('href');
+  });
+
+  test('An anchor element button should be able to receive event listeners', async function (assert) {
+    this.set('href', '#');
+    let clicked = false;
+    this.set('onClick', () => {
+      clicked = true;
+    });
+    await render(hbs`
+      <Boxel::Button @href={{ this.href }} {{ on "click" this.onClick }}>      
+        A disabled anchor
+      </Boxel::Button>
+    `);
+    await click(BUTTON_SELECTOR);
+    assert.equal(clicked, true);
+  });
+
+  // we can't test for disabled links because programmatic clicks bypass pointer-events:none
 });

--- a/tests/integration/components/boxel/button-test.js
+++ b/tests/integration/components/boxel/button-test.js
@@ -102,18 +102,22 @@ module('Integration | Component | Button', function (hooks) {
     assert.dom(BUTTON_SELECTOR).hasClass(/--size-base/);
   });
 
-  test('It can render an anchor element with the correct href if there is a href argument and a button otherwise', async function (assert) {
+  test('It can render as both anchor and link-to depending on @as', async function (assert) {
+    this.set('as', 'anchor');
     this.set('href', '#');
     await render(
-      hbs`<Boxel::Button @href={{ this.href }}>
+      hbs`<Boxel::Button @as={{ this.as }} @href={{ this.href }}>
           This should be an anchor
           </Boxel::Button>`
     );
     assert.dom(`a${BUTTON_SELECTOR}`).hasAttribute('href', '#');
     assert.dom(`button${BUTTON_SELECTOR}`).doesNotExist();
-    this.set('href', '');
+    this.set('as', '');
     assert.dom(`a${BUTTON_SELECTOR}`).doesNotExist();
     assert.dom(`button${BUTTON_SELECTOR}`).doesNotHaveAttribute('href');
+    this.set('as', 'link-to');
+    assert.dom(`a${BUTTON_SELECTOR}`).exists();
+    assert.dom(`button${BUTTON_SELECTOR}`).doesNotExist();
   });
 
   test('An anchor element button should be able to receive event listeners', async function (assert) {
@@ -124,7 +128,7 @@ module('Integration | Component | Button', function (hooks) {
     });
     await render(hbs`
       <Boxel::Button @href={{ this.href }} {{ on "click" this.onClick }}>      
-        A disabled anchor
+        An anchor
       </Boxel::Button>
     `);
     await click(BUTTON_SELECTOR);


### PR DESCRIPTION
This branches off #320, opening as a PR to main to trigger preview.

To avoid having to write a lot of link helper boilerplate when using this button for routing within the app, am adding LinkTo support to the Button component. This means adding `@route`, `@models`, and `@query` arguments - not the full suite, but probably enough for our use cases. In addition, in #320 we added `@href` for an external link.

This PR, in addition to these arguments, adds an `@as` argument for the user to be able to specify one of three tags/components to render in `Boxel::Button`. The `@as` argument accepts `button`, `anchor`, and `link-to`.

- `button` renders a `button`
- `anchor` renders an `a`
- `link-to` renders Ember's `LinkTo` component (which renders an `a`)

This makes it more explicit than conditionally rendering `a` and `LinkTo` based on `@href` and `@route`, and shifts the responsibility of deciding which argument takes precedence to the consumer if they choose to provide both arguments.