### PR TITLE
fix some typescript declaration error messages

### DIFF
--- a/addon/components/boxel/wave-player/index.ts
+++ b/addon/components/boxel/wave-player/index.ts
@@ -163,7 +163,7 @@ function makeScaler(domain: number, range: number) {
 
 async function decodeAudioData(
   audioContext: AudioContext,
-  buffer: Buffer
+  buffer: ArrayBuffer
 ): Promise<AudioBuffer> {
   return await new Promise((resolve) =>
     audioContext.decodeAudioData(buffer, resolve)

--- a/addon/declarations.d.ts
+++ b/addon/declarations.d.ts
@@ -1,17 +1,19 @@
-export {};
-
-declare global {
-  interface Window {
-    webkitAudioContext: typeof AudioContext;
-  }
-}
-
-declare module '**/*.png' {
+declare module '*.svg' {
   const value: string;
   export default value;
 }
 
-declare module '**/*.jpg' {
+declare module '*.png' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.jpg' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.flac' {
   const value: string;
   export default value;
 }

--- a/addon/webkit-audio-context.d.ts
+++ b/addon/webkit-audio-context.d.ts
@@ -1,0 +1,7 @@
+export {};
+
+declare global {
+  interface Window {
+    webkitAudioContext: typeof AudioContext;
+  }
+}

--- a/tests/dummy/app/config/environment.d.ts
+++ b/tests/dummy/app/config/environment.d.ts
@@ -1,5 +1,3 @@
-export default config;
-
 /**
  * Type declarations for
  *    import config from 'my-app/config/environment'


### PR DESCRIPTION
Changes:
1. Only one * for wildcard module declarations
2. Move the global webkit audio declaration to a separate file to stop it from breaking other declarations with the `export`
3. Added a few declaration types for `svg` and `flac`
4. Remove `export default config` from the `environment.d.ts` which doesn't seem to be needed
5. Change `Buffer` -> `ArrayBuffer` to fix error message

I don't fully understand what is happening here, will do a bit more reading, but putting this here for visibility first.