### PR TITLE
Make sure correct disabledClass applies

### DIFF
--- a/addon/components/boxel/button/index.hbs
+++ b/addon/components/boxel/button/index.hbs
@@ -27,8 +27,8 @@
     @route={{@route}}
     @models={{if @models @models (array)}}
     @query={{@query}}
-    @disabled={{@disabled}}
     @disabledClass="boxel-button--disabled-link"
+    @disabled={{@disabled}}
     data-test-boxel-button 
     tabindex={{if @disabled -1 0}}
     ...attributes


### PR DESCRIPTION
CS-550

Order of arguments provided matters if we want the correct `@disabledClass` to apply to our component on first render - updates to state seem to be fine.

There is an old issue here: https://github.com/emberjs/ember.js/issues/16864, but unsure how much actually applies to current code. Will submit a reproduction later.