### PR TITLE
loading button

### DIFF
--- a/addon/components/boxel/button/index.css
+++ b/addon/components/boxel/button/index.css
@@ -28,20 +28,41 @@
   letter-spacing: var(--boxel-button-letter-spacing, var(--boxel-lsp-lg));
 }
 
+.boxel-button__loading-indicator {
+  --icon-color: var(--boxel-button-text-color);
+  width: var(--boxel-button-loading-icon-size);
+  height: var(--boxel-button-loading-icon-size);
+  margin-right: var(--boxel-sp-xxxs);
+}
+
 /* select disabled buttons and links that don't have href */
 /* 
   a.boxel-button--disabled-link is a special case for an automatically appended class by the LinkTo component 
   the LinkTo component appends the href regardless, so we have to select it in other ways.
   Removing the chained classes will make kind-variants overwrite the disabled style on the LinkTo (specificity issues)
 */
-.boxel-button:disabled, a.boxel-button:not([href]),a.boxel-button[href=""], a.boxel-button.boxel-button--disabled-link {
+.boxel-button:disabled, 
+a.boxel-button:not([href]),
+a.boxel-button[href=""], 
+a.boxel-button.boxel-button--disabled-link {
   --boxel-button-color: var(--boxel-purple-300);
   --boxel-button-border: 1px solid var(--boxel-purple-300);
   --boxel-button-text-color: var(--boxel-purple-400);
 }
 
 /* the a element does not have a disabled attribute. Clicking will still trigger event listeners */
-a.boxel-button:not([href]),a.boxel-button[href=""], a.boxel-button.boxel-button--disabled-link {
+a.boxel-button:not([href]),
+a.boxel-button[href=""], 
+a.boxel-button.boxel-button--disabled-link {
+  pointer-events: none;
+}
+
+/* 
+  loading state. 
+  this should only be relevant for buttons - links shouldn't need it. 
+  We want to preserve the "normal" styling of the button but not allow interaction
+*/
+.boxel-button--loading {
   pointer-events: none;
 }
 

--- a/addon/components/boxel/button/index.hbs
+++ b/addon/components/boxel/button/index.hbs
@@ -5,11 +5,15 @@
  ) as |classes|}}
 {{#if (or (not @as) (eq @as "button"))}}
   <button
-    class={{classes}}
+    class={{cn classes (if @loading "boxel-button--loading")}}
+    tabindex={{if @loading -1 0}}
     disabled={{@disabled}}
     data-test-boxel-button
     ...attributes
   >
+  {{#if @loading}}
+    {{svg-jar "loading-indicator" class="boxel-button__loading-indicator"}}
+  {{/if}}
     {{yield}}
   </button>
 {{else if (eq @as "anchor")}}

--- a/addon/components/boxel/button/size-variants.css
+++ b/addon/components/boxel/button/size-variants.css
@@ -11,12 +11,14 @@
  * --boxel-button-min-height
  * --boxel-button-font
  * --boxel-button-letter-spacing
+ * --boxel-button-loading-icon-size
  * 
  */
  /* thinner base button */
 .boxel-button--size-small {
   --boxel-button-padding: var(--boxel-sp-xxxs) var(--boxel-sp);
   --boxel-button-font: 600 var(--boxel-font-sm);
+  --boxel-button-loading-icon-size: var(--boxel-font-size-sm);
   --boxel-button-letter-spacing: var(--boxel-lsp);
   --boxel-button-min-height: 2rem;
 }
@@ -24,6 +26,7 @@
 .boxel-button--size-base {
   --boxel-button-padding: var(--boxel-sp-xxxs) var(--boxel-sp-xl);
   --boxel-button-font: 600 var(--boxel-font-sm);
+  --boxel-button-loading-icon-size: var(--boxel-font-size-sm);
   --boxel-button-letter-spacing: var(--boxel-lsp);
   --boxel-button-min-height: 2rem;
 }
@@ -32,6 +35,7 @@
 .boxel-button--size-tall {
   --boxel-button-padding: var(--boxel-sp-xs) var(--boxel-sp-lg);
   --boxel-button-font: 600 var(--boxel-font-sm);
+  --boxel-button-loading-icon-size: var(--boxel-font-size-sm);
   --boxel-button-letter-spacing: var(--boxel-lsp);
   --boxel-button-min-height: 2.5rem;
 }
@@ -43,6 +47,7 @@
 .boxel-button--size-touch {
   --boxel-button-padding: var(--boxel-sp-xs) var(--boxel-sp-lg);
   --boxel-button-font: 600 var(--boxel-font);
+  --boxel-button-loading-icon-size: var(--boxel-font-size);
   --boxel-button-letter-spacing: var(--boxel-lsp-xs);
   --boxel-button-min-height: 3rem;
 }

--- a/addon/components/boxel/button/usage.hbs
+++ b/addon/components/boxel/button/usage.hbs
@@ -25,6 +25,7 @@
             <li><code>@size</code></li>
             <li><code>@kind</code></li>
             <li><code>@disabled</code></li>
+            <li><code>@loading</code></li>
           </ul>
         </td>
         <td>
@@ -77,8 +78,10 @@
         @kind={{this.kind}}
         @size={{this.size}}
         @disabled={{this.disabled}}
+        @loading={{this.loading}}
         @href={{this.href}}
         @route={{this.route}}
+        {{on "click" this.alert}}
       >
         Button Text
       </Boxel::Button>
@@ -142,6 +145,13 @@
       @description="Controls whether the button is disabled"
       @onInput={{fn (mut this.disabled)}}
       @value={{this.disabled}}
+    />
+    <Args.Bool
+      @name="loading"
+      @optional={{true}}
+      @description="Controls whether the button is loading."
+      @onInput={{fn (mut this.loading)}}
+      @value={{this.loading}}
     />
     <Args.Yield @description="Contents of the button" />
   </:api>

--- a/addon/components/boxel/button/usage.ts
+++ b/addon/components/boxel/button/usage.ts
@@ -15,6 +15,7 @@ export default class extends Component {
   @tracked size = 'base';
   @tracked kind = 'primary';
   @tracked disabled = false;
+  @tracked loading = false;
 
   // for @as === 'anchor'
   @tracked href = '#';

--- a/public/images/icons/loading-indicator.svg
+++ b/public/images/icons/loading-indicator.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15.5 15.5">
+  <g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+    <path d="M12,2V4.8" transform="translate(0.75 0.75) translate(-5 -2)"/>
+    <path d="M12,18v2.8" transform="translate(0.75 0.75) translate(-5 -6.8)"/>
+    <path d="M4.93,4.93,6.911,6.911" transform="translate(0.75 0.75) translate(-2.879 -2.879)"/>
+    <path d="M16.24,16.24l1.981,1.981" transform="translate(0.75 0.75) translate(-6.272 -6.272)"/>
+    <path d="M2,12H4.8" transform="translate(0.75 0.75) translate(-2 -5)"/>
+    <path d="M18,12h2.8" transform="translate(0.75 0.75) translate(-6.8 -5)"/>
+    <path d="M4.93,18.221,6.911,16.24" transform="translate(0.75 0.75) translate(-2.879 -6.272)"/>
+    <path d="M16.24,6.911,18.221,4.93" transform="translate(0.75 0.75) translate(-6.272 -2.879)"/>
+  </g>
+</svg>


### PR DESCRIPTION
CS-560

Adds loading state to button. 

![image](https://user-images.githubusercontent.com/39579264/114364286-d4fd1200-9bab-11eb-8101-bbec3cf8b936.png)

In the loading state, the button is not interactive. A loading spinner is added by the component, on the left side of the button - within the button's layout flow so that it can be centered.

### Some possible follow ups
1. Convert `@loading` and `@disabled` to a single argument `@state` - since you probably shouldn't have a loading AND disabled button? Right now it works though.
2. Change the button to accept a `@onClick` argument. This allows better interception of actions on the button when loading. 

### Why not just add the `disabled` attribute?
Screen reader jumps from the button to other things: https://gomakethings.com/dont-disable-buttons-while-submitting-forms-with-ajax/