### PR TITLE
Cardpay workflow layout card

### DIFF
--- a/addon/components/boxel/cardpay-workflow-layout-card/index.css
+++ b/addon/components/boxel/cardpay-workflow-layout-card/index.css
@@ -1,3 +1,4 @@
+/* stylelint-disable */
 .cardpay-workflow-layout-card {
   --horizontal-padding: var(--boxel-sp-lg);
   filter: drop-shadow(0 15px 30px rgba(0, 0, 0, 0.15));

--- a/addon/components/boxel/cardpay-workflow-layout-card/index.css
+++ b/addon/components/boxel/cardpay-workflow-layout-card/index.css
@@ -1,0 +1,8 @@
+.cardpay-workflow-layout-card {
+  --horizontal-padding: var(--boxel-sp-lg);
+  filter: drop-shadow(0 15px 30px rgba(0, 0, 0, 0.15));
+}
+
+.cardpay-workflow-layout-card-body {
+  padding: 0 var(--horizontal-padding);
+}

--- a/addon/components/boxel/cardpay-workflow-layout-card/index.hbs
+++ b/addon/components/boxel/cardpay-workflow-layout-card/index.hbs
@@ -1,0 +1,7 @@
+<Boxel::CardContainer class="cardpay-workflow-layout-card">
+  {{yield (component "boxel/header" editable=false expandable=false hasContextMenu=false) to="header"}}
+  <div class="cardpay-workflow-layout-card-body">
+    {{yield (component "boxel/cardpay-workflow-layout-card/section") to="body"}}
+  </div>
+  {{yield (component "boxel/cta-block") to="footer"}}
+</Boxel::CardContainer>

--- a/addon/components/boxel/cardpay-workflow-layout-card/section/index.css
+++ b/addon/components/boxel/cardpay-workflow-layout-card/section/index.css
@@ -1,3 +1,4 @@
+/* stylelint-disable */
 .cardpay-workflow-layout-card__section + .cardpay-workflow-layout-card__section {
     border-top: 1px solid #efefef;
 }

--- a/addon/components/boxel/cardpay-workflow-layout-card/section/index.css
+++ b/addon/components/boxel/cardpay-workflow-layout-card/section/index.css
@@ -1,0 +1,22 @@
+.cardpay-workflow-layout-card__section + .cardpay-workflow-layout-card__section {
+    border-top: 1px solid #efefef;
+}
+
+.cardpay-workflow-layout-card__section-header {
+  padding: var(--boxel-sp-xl) 0;
+  max-height: 6rem;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.cardpay-workflow-layout-card__section-icon {
+    
+}
+
+.cardpay-workflow-layout-card__section-logo {
+    
+}
+
+.cardpay-workflow-layout-card__section-body {
+  margin-bottom: var(--boxel-sp-xl);
+}

--- a/addon/components/boxel/cardpay-workflow-layout-card/section/index.hbs
+++ b/addon/components/boxel/cardpay-workflow-layout-card/section/index.hbs
@@ -11,6 +11,6 @@
     </header>
   {{/if}}
   <div class="cardpay-workflow-layout-card__section-body">
-      {{yield}}
-    </div>
+    {{yield}}
+  </div>
 </section>

--- a/addon/components/boxel/cardpay-workflow-layout-card/section/index.hbs
+++ b/addon/components/boxel/cardpay-workflow-layout-card/section/index.hbs
@@ -1,0 +1,16 @@
+<section class="cardpay-workflow-layout-card__section" ...attributes>
+  {{#if @headerText}}
+    <header class="cardpay-workflow-layout-card__section-header">
+      {{#if @icon}}
+        {{svg-jar @icon class="cardpay-workflow-layout-card__section-logo"}}
+      {{/if}}
+      {{@headerText}}
+      {{#if @logo}}
+        <img class="cardpay-workflow-layout-card__section-logo" src={{@logo}} alt="" role="presentation">
+      {{/if}}
+    </header>
+  {{/if}}
+  <div class="cardpay-workflow-layout-card__section-body">
+      {{yield}}
+    </div>
+</section>

--- a/addon/components/boxel/cardpay-workflow-layout-card/usage.hbs
+++ b/addon/components/boxel/cardpay-workflow-layout-card/usage.hbs
@@ -56,12 +56,12 @@
     />
     <Args.String
       @name="icon"
-      @description="Icon to be shown before the header text"
+      @description="[WIP] Icon to be shown before the header text"
       @optional={{true}}
     />
     <Args.String
       @name="logo"
-      @description="Logo to be shown at the end of the header text"
+      @description="[WIP] Logo to be shown at the end of the header text"
       @optional={{true}}
     />
   </:api>

--- a/addon/components/boxel/cardpay-workflow-layout-card/usage.hbs
+++ b/addon/components/boxel/cardpay-workflow-layout-card/usage.hbs
@@ -1,0 +1,26 @@
+<Freestyle::Usage>
+    <:example>
+      <Boxel::CardpayWorkflowLayoutCard>
+        <:header as |Header|>
+          <Header @header="Header text"/>
+        </:header>
+        <:body as |Section|>
+          <Section @headerText="Section 1">
+            Body content
+          </Section>
+          <Section @headerText="Section 2">
+            Body content
+          </Section>
+        </:body>
+        <:footer as |CtaBlock|>
+          <CtaBlock @state="default">
+            <:default as |a|>
+              <a.ActionButton>
+                Cta here.
+              </a.ActionButton>
+            </:default>
+          </CtaBlock>
+        </:footer>
+      </Boxel::CardpayWorkflowLayoutCard>
+    </:example>
+</Freestyle::Usage>

--- a/addon/components/boxel/cardpay-workflow-layout-card/usage.hbs
+++ b/addon/components/boxel/cardpay-workflow-layout-card/usage.hbs
@@ -45,7 +45,7 @@
     This is one section
   </Boxel::CardpayWorkflowLayoutCard::Section>
   <Boxel::CardpayWorkflowLayoutCard::Section @icon="" @logo="">
-    This is another section with no header - though this does not occur in current design.
+    This is another section with no header.
   </Boxel::CardpayWorkflowLayoutCard::Section>
   </:example>
   <:api as |Args|>

--- a/addon/components/boxel/cardpay-workflow-layout-card/usage.hbs
+++ b/addon/components/boxel/cardpay-workflow-layout-card/usage.hbs
@@ -23,4 +23,46 @@
         </:footer>
       </Boxel::CardpayWorkflowLayoutCard>
     </:example>
+    <:api as |Args|>
+      <Args.Yield
+        @name="header"
+        @description="Yields the Boxel Header component with some presets"
+      />
+      <Args.Yield
+        @name="body"
+        @description="Yields a Section component that scaffolds some layout"
+      />
+      <Args.Yield
+        @name="footer"
+        @description="Yields the Boxel CtaBlock component"
+      />
+    </:api>
+</Freestyle::Usage>
+
+<Freestyle::Usage>
+  <:example>
+  <Boxel::CardpayWorkflowLayoutCard::Section @headerText="Header Text" @icon="" @logo="">
+    This is one section
+  </Boxel::CardpayWorkflowLayoutCard::Section>
+  <Boxel::CardpayWorkflowLayoutCard::Section @icon="" @logo="">
+    This is another section with no header - though this does not occur in current design.
+  </Boxel::CardpayWorkflowLayoutCard::Section>
+  </:example>
+  <:api as |Args|>
+    <Args.String
+      @name="Header Text"
+      @description="Header text for the section. If not provided, will not render a header."
+      @optional={{true}}
+    />
+    <Args.String
+      @name="icon"
+      @description="Icon to be shown before the header text"
+      @optional={{true}}
+    />
+    <Args.String
+      @name="logo"
+      @description="Logo to be shown at the end of the header text"
+      @optional={{true}}
+    />
+  </:api>
 </Freestyle::Usage>


### PR DESCRIPTION
Builds on the CardContainer component with some layout defaults for CardPay, using Boxel's Header and CtaBlock components. Adds Sections to scaffold layout.

![image](https://user-images.githubusercontent.com/39579264/115018961-1c0c3f80-9eeb-11eb-86e0-faaf6bc98ddb.png)
![image](https://user-images.githubusercontent.com/39579264/115019821-49a5b880-9eec-11eb-8236-0fab840b2bfd.png)
![image](https://user-images.githubusercontent.com/39579264/115019730-2d098080-9eec-11eb-9e51-7ba181149466.png)
