### PR TITLE
prevent radio button focus from making page jump

### DIFF
--- a/addon/components/boxel/custom-radio/container/index.css
+++ b/addon/components/boxel/custom-radio/container/index.css
@@ -12,4 +12,5 @@
   left: -9999px;
   max-width: 1px;
   max-height: 1px;
+  white-space: nowrap;
 }

--- a/addon/components/boxel/custom-radio/item/index.css
+++ b/addon/components/boxel/custom-radio/item/index.css
@@ -9,6 +9,8 @@
 /* https://css-tricks.com/customise-radio-buttons-without-compromising-accessibility/ */
 .boxel-custom-radio__hidden-input {
   position: absolute;
+  top: 0;
+  left: 0;
   clip-path: polygon(0 0);
   width: 1px;
   height: 1px;

--- a/addon/components/boxel/custom-radio/item/index.hbs
+++ b/addon/components/boxel/custom-radio/item/index.hbs
@@ -9,18 +9,17 @@ aria-labelledby seems friendlier to safari than the for element, but unsure abou
   for={{@id}} 
   {{!-- id={{concat "checkbox-label-for-" @id}} --}}
 >
-    {{yield}}
+  <Input
+    @type="radio"
+    @id={{@id}} 
+    @value={{or @value @id}} 
+    @checked={{@checked}}
+    name={{@name}}
+    class="boxel-custom-radio__hidden-input" 
+    {{!-- aria-labelledby={{concat "checkbox-label-for-" @id}} --}}
+    {{on "change" (optional @onChange)}} 
+    {{on "focusin" (fn (mut this.focused) true)}}
+    {{on "focusout" (fn (mut this.focused) false)}}
+  />
+  {{yield}}
 </label>
-
-<Input
-  @type="radio"
-  @id={{@id}} 
-  @value={{or @value @id}} 
-  @checked={{@checked}}
-  name={{@name}}
-  class="boxel-custom-radio__hidden-input" 
-  {{!-- aria-labelledby={{concat "checkbox-label-for-" @id}} --}}
-  {{on "change" (optional @onChange)}} 
-  {{on "focusin" (fn (mut this.focused) true)}}
-  {{on "focusout" (fn (mut this.focused) false)}}
-/>


### PR DESCRIPTION
also make hidden legend field text single line so that screenreader gets it all at once