### PR TITLE
add an extra-small variant for buttons

### DIFF
--- a/addon/components/boxel/button/size-variants.css
+++ b/addon/components/boxel/button/size-variants.css
@@ -15,6 +15,14 @@
  *
  */
 
+.boxel-button--size-extra-small {
+  --boxel-button-padding: var(--boxel-sp-xxxs) var(--boxel-sp);
+  --boxel-button-font: var(--boxel-font-xs);
+  --boxel-button-loading-icon-size: var(--boxel-font-size-xs);
+  --boxel-button-letter-spacing: var(--boxel-lsp-lg);
+  --boxel-button-min-height: 1.8125rem;
+}
+
 /* thinner base button */
 .boxel-button--size-small {
   --boxel-button-padding: var(--boxel-sp-xxxs) var(--boxel-sp);

--- a/addon/components/boxel/button/usage.ts
+++ b/addon/components/boxel/button/usage.ts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 export default class extends Component {
-  sizeVariants = ['small', 'base', 'tall', 'touch'];
+  sizeVariants = ['extra-small', 'small', 'base', 'tall', 'touch'];
   kindVariants = {
     all: ['primary', 'secondary-light', 'secondary-dark'],
     light: ['primary', 'secondary-light'],


### PR DESCRIPTION
Difference from the 'small' size is typography and resulting min-height. This button is used in a few parts of the workflows.

![image](https://user-images.githubusercontent.com/39579264/116087682-b03c8a80-a6d3-11eb-9236-485490c88f11.png)
