### PR TITLE
Enhancement/thread message layout

### DIFF
--- a/addon/components/boxel/thread-message/index.css
+++ b/addon/components/boxel/thread-message/index.css
@@ -31,16 +31,6 @@
   border-radius: initial;
 }
 
-.boxel-thread-message__initial {
-  width: var(--boxel-thread-message-avatar-size);
-  height: var(--boxel-thread-message-avatar-size);
-  border: var(--boxel-border);
-  border-radius: 100px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
 .boxel-thread-message__info {
   display: flex;
   align-items: center;

--- a/addon/components/boxel/thread-message/index.css
+++ b/addon/components/boxel/thread-message/index.css
@@ -1,9 +1,8 @@
 .boxel-thread-message {
-  --boxel-thread-message-avatar-size: calc(2 * var(--boxel-sp));
+  --boxel-thread-message-avatar-size: 2.5rem; /* 40px. Avatar should not be set to be larger than 60px or smaller than 20px. */
+  --boxel-thread-message-meta-height: 1.25rem; /* 20px */
   --boxel-thread-message-gap: var(--boxel-sp);
-  --boxel-thread-message-meta-height: var(--boxel-sp); /* set the height to the text height so that we can do layout based on this */
-
-  min-height: var(--boxel-thread-message-avatar-size); /* if meta is showing, we need to account for short heights which might (unlikely) lead to overlap with other text messages */
+  --boxel-thread-message-margin-left: calc(var(--boxel-thread-message-avatar-size) + var(--boxel-thread-message-gap));
 }
 
 .boxel-thread-message--hide-meta {
@@ -12,18 +11,14 @@
 
 .boxel-thread-message__meta {
   display: grid;
-  grid-template-columns: var(--boxel-thread-message-avatar-size) 1fr var(--boxel-thread-message-avatar-size);
+  grid-template-columns: var(--boxel-thread-message-avatar-size) 1fr;
   grid-template-rows: var(--boxel-thread-message-meta-height);
   align-items: start;
   gap: var(--boxel-thread-message-gap);
 }
 
-.boxel-thread-message--card .boxel-thread-message__meta {
+.boxel-thread-message--full-width .boxel-thread-message__meta {
   align-items: center;
-}
-
-.boxel-thread-message__avatar {
-  width: var(--boxel-thread-message-avatar-size);
 }
 
 .boxel-thread-message__avatar-img {
@@ -38,9 +33,7 @@
 
 .boxel-thread-message__info {
   display: flex;
-  align-items: center;
   white-space: nowrap;
-  height: var(--boxel-thread-message-meta-height); /* 20px */
   margin: 0;
   font: 600 var(--boxel-font-sm);
   letter-spacing: var(--boxel-lsp);
@@ -57,24 +50,18 @@
 }
 
 .boxel-thread-message__content {
-  /* mimic the grid using margins, but don't use grid - if multiple items are children of a thread message, grid will mess things up. */
-  width: calc(100% - 2 * (var(--boxel-thread-message-gap) + var(--boxel-thread-message-avatar-size)));
-  margin-left: auto;
-  margin-right: auto;
-  transition: width var(--boxel-transition);
+  /* mimic the grid using margins */
+  margin-left: var(--boxel-thread-message-margin-left);
 }
 
-.boxel-thread-message--card .boxel-thread-message__content {
+.boxel-thread-message--full-width .boxel-thread-message__content {
+  margin-left: 0;
   margin-top: var(--boxel-sp);
-}
-
-.boxel-thread-message--full-content-width .boxel-thread-message__content {
-  width: 100%;
 }
 
 /* spacing for sequential thread messages */
 .boxel-thread-message + .boxel-thread-message {
-  margin-top: calc(2 * var(--boxel-sp));
+  margin-top: var(--boxel-sp-xl);
 }
 
 .boxel-thread-message + .boxel-thread-message--hide-meta {

--- a/addon/components/boxel/thread-message/index.css
+++ b/addon/components/boxel/thread-message/index.css
@@ -1,20 +1,26 @@
 .boxel-thread-message {
-  --boxel-thread-message-avatar-size: 2.5rem;
+  --boxel-thread-message-avatar-size: calc(2 * var(--boxel-sp));
+  --boxel-thread-message-gap: var(--boxel-sp);
+  --boxel-thread-message-meta-height: var(--boxel-sp); /* set the height to the text height so that we can do layout based on this */
+  --child-card-margin: var(--boxel-sp);
 
+  min-height: var(--boxel-thread-message-avatar-size); /* if meta is showing, we need to account for short heights which might (unlikely) lead to overlap with other text messages */
+}
+
+.boxel-thread-message--hide-meta {
+  min-height: 0;
+}
+
+.boxel-thread-message__meta {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: var(--boxel-thread-message-avatar-size) 1fr var(--boxel-thread-message-avatar-size);
+  grid-template-rows: var(--boxel-thread-message-meta-height);
   align-items: start;
-  gap: var(--boxel-sp);
+  gap: var(--boxel-thread-message-gap);
 }
 
-@media only screen and (min-width: 1440px) {
-  .boxel-thread-message {
-    padding-right: var(--boxel-sp-xl);
-  }
-}
-
-.boxel-thread-message + .boxel-thread-message {
-  margin-top: var(--boxel-sp-lg);
+.boxel-thread-message--card .boxel-thread-message__meta {
+  align-items: center;
 }
 
 .boxel-thread-message__avatar {
@@ -35,7 +41,7 @@
   display: flex;
   align-items: center;
   white-space: nowrap;
-  min-height: 1.25rem; /* 20px */
+  height: var(--boxel-thread-message-meta-height); /* 20px */
   margin: 0;
   font: 600 var(--boxel-font-sm);
   letter-spacing: var(--boxel-lsp);
@@ -49,4 +55,29 @@
   color: var(--boxel-purple-400);
   font-size: var(--boxel-font-size-xs);
   letter-spacing: var(--boxel-lsp-lg);
+}
+
+.boxel-thread-message__content {
+  /* mimic the grid using margins, but don't use grid - if multiple items are children of a thread message, grid will mess things up. */
+  width: calc(100% - 2 * (var(--boxel-thread-message-gap) + var(--boxel-thread-message-avatar-size)));
+  margin-left: auto;
+  margin-right: auto;
+  transition: width var(--boxel-transition);
+}
+
+.boxel-thread-message--card .boxel-thread-message__content {
+  margin-top: var(--child-card-margin);
+}
+
+.boxel-thread-message--full-content-width .boxel-thread-message__content {
+  width: 100%;
+}
+
+/* spacing for sequential thread messages */
+.boxel-thread-message + .boxel-thread-message {
+  margin-top: calc(2 * var(--boxel-sp));
+}
+
+.boxel-thread-message + .boxel-thread-message--hide-meta {
+  margin-top: var(--boxel-sp);
 }

--- a/addon/components/boxel/thread-message/index.css
+++ b/addon/components/boxel/thread-message/index.css
@@ -2,7 +2,6 @@
   --boxel-thread-message-avatar-size: calc(2 * var(--boxel-sp));
   --boxel-thread-message-gap: var(--boxel-sp);
   --boxel-thread-message-meta-height: var(--boxel-sp); /* set the height to the text height so that we can do layout based on this */
-  --child-card-margin: var(--boxel-sp);
 
   min-height: var(--boxel-thread-message-avatar-size); /* if meta is showing, we need to account for short heights which might (unlikely) lead to overlap with other text messages */
 }
@@ -66,7 +65,7 @@
 }
 
 .boxel-thread-message--card .boxel-thread-message__content {
-  margin-top: var(--child-card-margin);
+  margin-top: var(--boxel-sp);
 }
 
 .boxel-thread-message--full-content-width .boxel-thread-message__content {

--- a/addon/components/boxel/thread-message/index.hbs
+++ b/addon/components/boxel/thread-message/index.hbs
@@ -1,11 +1,10 @@
-<div 
- class={{cn 
-   "boxel-thread-message" 
-   boxel-thread-message--hide-meta=@hideMeta 
-   boxel-thread-message--card=@containsCard 
-   boxel-thread-message--full-content-width=(and @fullWidth @containsCard)
-  }} 
- data-test-boxel-thread-message 
+<div
+ class={{cn
+   "boxel-thread-message"
+   boxel-thread-message--hide-meta=@hideMeta
+   boxel-thread-message--full-width=@fullWidth
+  }}
+ data-test-boxel-thread-message
  ...attributes
 >
   <div class={{cn "boxel-thread-message__meta"  boxel-sr-only=@hideMeta}}>

--- a/addon/components/boxel/thread-message/index.hbs
+++ b/addon/components/boxel/thread-message/index.hbs
@@ -1,5 +1,14 @@
-<div class="boxel-thread-message" data-test-boxel-thread-message ...attributes>
-  <span class="boxel-thread-message__avatar">
+<div 
+ class={{cn 
+   "boxel-thread-message" 
+   boxel-thread-message--hide-meta=@hideMeta 
+   boxel-thread-message--card=@containsCard 
+   boxel-thread-message--full-content-width=(and @fullWidth @containsCard)
+  }} 
+ data-test-boxel-thread-message 
+ ...attributes
+>
+  <div class={{cn "boxel-thread-message__meta"  boxel-sr-only=@hideMeta}}>
     {{#unless @hideMeta}}
       {{#if @imgURL}}
         <img
@@ -14,9 +23,7 @@
         {{svg-jar "profile" width="40px" height="40px" aria-label=(or @name "participant")}}
       {{/if}}
     {{/unless}}
-  </span>
-  <span>
-    <h3 class={{cn "boxel-thread-message__info" boxel-sr-only=@hideMeta}}>
+    <h3 class="boxel-thread-message__info">
       {{#if @name}}
         <span class={{cn "boxel-thread-message__name" boxel-sr-only=@hideName}} data-test-boxel-thread-message-name>
           {{@name}}
@@ -26,7 +33,8 @@
         {{dayjs-format (or @datetime (now)) "MMM D, h:mm A"}}
       </time>
     </h3>
-
+  </div>
+  <div class="boxel-thread-message__content">
     {{yield}}
-  </span>
+  </div>
 </div>

--- a/addon/components/boxel/thread-message/usage.css
+++ b/addon/components/boxel/thread-message/usage.css
@@ -1,8 +1,8 @@
 .thread-message-usage-card {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 1.25rem;
-    background: var(--boxel-purple-600);
-    box-shadow: 0 15px 30px rgba(0, 0, 0, 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.25rem;
+  background: var(--boxel-purple-600);
+  box-shadow: 0 15px 30px rgba(0, 0, 0, 0.15);
 }

--- a/addon/components/boxel/thread-message/usage.css
+++ b/addon/components/boxel/thread-message/usage.css
@@ -1,8 +1,21 @@
-.thread-message-usage-card {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1.25rem;
-  background: var(--boxel-purple-600);
+.thread-message-usage {
+  --inner-max-width: 36.6rem; /* ~585px */
+  --outer-max-width: 43.75rem; /* 700px; */
+}
+
+.thread-message-usage__content {
+  max-width: var(--inner-max-width);
+  margin: 0;
+}
+
+.thread-message-usage__card {
+  max-width: var(--outer-max-width);
   box-shadow: 0 15px 30px rgba(0, 0, 0, 0.15);
+  transition: all var(--boxel-transition);
+}
+
+.thread-message-usage__card--memorialized {
+  max-width: var(--inner-max-width);
+  margin-left: var(--boxel-thread-message-margin-left);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
 }

--- a/addon/components/boxel/thread-message/usage.css
+++ b/addon/components/boxel/thread-message/usage.css
@@ -1,0 +1,8 @@
+.thread-message-usage-card {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.25rem;
+    background: var(--boxel-purple-600);
+    box-shadow: 0 15px 30px rgba(0, 0, 0, 0.15);
+}

--- a/addon/components/boxel/thread-message/usage.hbs
+++ b/addon/components/boxel/thread-message/usage.hbs
@@ -102,14 +102,12 @@
   <:example>
     <div>
       <Boxel::ThreadMessage
-        role="listitem"
         @name="Cardbot"
         @imgURL={{this.cardbotIcon}}
       >
         First thread message does not apply margins.
       </Boxel::ThreadMessage>
       <Boxel::ThreadMessage
-        role="listitem"
         @name="Cardbot"
         @imgURL={{this.cardbotIcon}}
         @hideMeta={{true}}
@@ -117,14 +115,12 @@
         A message with meta hidden has a margin-top of 1.25rem. 
       </Boxel::ThreadMessage>
       <Boxel::ThreadMessage
-        role="listitem"
         @name="Cardbot"
         @imgURL={{this.cardbotIcon}}
       >
         A message without meta hidden has a margin-top of 2.5rem. 
       </Boxel::ThreadMessage>
       <Boxel::ThreadMessage
-        role="listitem"
         @name="Cardbot"
         @imgURL={{this.cardbotIcon}}
         @hideMeta={{true}}
@@ -132,7 +128,6 @@
         The following message which contains a card will have its meta centered relative to its avatar.
       </Boxel::ThreadMessage>
       <Boxel::ThreadMessage
-        role="listitem"
         @name="Cardbot"
         @imgURL={{this.cardbotIcon}}
         @containsCard={{true}}

--- a/addon/components/boxel/thread-message/usage.hbs
+++ b/addon/components/boxel/thread-message/usage.hbs
@@ -7,6 +7,8 @@
       @notRound={{this.notRound}}
       @hideMeta={{this.hideMeta}}
       @hideName={{this.hideName}}
+      @fullWidth={{this.fullWidth}}
+      @containsCard={{this.containsCard}}
     >
       Hi Haley, Here’s your manuscript with all the edits I would recommend. Please review and let me know if you have any questions. I also added a couple tasks for you about things you should think about, as you figure out the rest of your story.
     </Boxel::ThreadMessage>
@@ -57,6 +59,20 @@
       @defaultValue={{false}}
       @onInput={{fn (mut this.hideName)}}
     />
+    <Args.Bool
+      @name="fullWidth"
+      @value={{this.fullWidth}}
+      @description="Whether to allocate the full width to the content. This only works if containsCard is also true"
+      @defaultValue={{false}}
+      @onInput={{fn (mut this.fullWidth)}}
+    />
+    <Args.Bool
+      @name="containsCard"
+      @value={{this.containsCard}}
+      @description="Whether or not the ThreadMessage contains a card as its first child. This modifies some layout rules for the message meta."
+      @defaultValue={{false}}
+      @onInput={{fn (mut this.containsCard)}}
+    />
   </:api>
 </Freestyle::Usage>
 
@@ -76,6 +92,58 @@
           {{message}}
         </Boxel::ThreadMessage>
       {{/each}}
+    </div>
+  </:example>
+</Freestyle::Usage>
+
+<Freestyle::Usage
+  @description="Layout rules displayed"
+>
+  <:example>
+    <div>
+      <Boxel::ThreadMessage
+        role="listitem"
+        @name="Cardbot"
+        @imgURL={{this.cardbotIcon}}
+      >
+        First thread message does not apply margins.
+      </Boxel::ThreadMessage>
+      <Boxel::ThreadMessage
+        role="listitem"
+        @name="Cardbot"
+        @imgURL={{this.cardbotIcon}}
+        @hideMeta={{true}}
+      >
+        A message with meta hidden has a margin-top of 1.25rem. 
+      </Boxel::ThreadMessage>
+      <Boxel::ThreadMessage
+        role="listitem"
+        @name="Cardbot"
+        @imgURL={{this.cardbotIcon}}
+      >
+        A message without meta hidden has a margin-top of 2.5rem. 
+      </Boxel::ThreadMessage>
+      <Boxel::ThreadMessage
+        role="listitem"
+        @name="Cardbot"
+        @imgURL={{this.cardbotIcon}}
+        @hideMeta={{true}}
+      >
+        The following message which contains a card will have its meta centered relative to its avatar.
+      </Boxel::ThreadMessage>
+      <Boxel::ThreadMessage
+        role="listitem"
+        @name="Cardbot"
+        @imgURL={{this.cardbotIcon}}
+        @containsCard={{true}}
+        @fullWidth={{this.layoutExampleFullWidth}}
+      >
+        <Boxel::CardContainer 
+          class="thread-message-usage-card"
+        >
+          <Boxel::Button @kind="primary" {{on "click" this.toggleLayoutExampleFullWidth}}>Click to toggle @fullWidth</Boxel::Button>
+        </Boxel::CardContainer>
+      </Boxel::ThreadMessage>
     </div>
   </:example>
 </Freestyle::Usage>

--- a/addon/components/boxel/thread-message/usage.hbs
+++ b/addon/components/boxel/thread-message/usage.hbs
@@ -8,7 +8,6 @@
       @hideMeta={{this.hideMeta}}
       @hideName={{this.hideName}}
       @fullWidth={{this.fullWidth}}
-      @containsCard={{this.containsCard}}
     >
       Hi Haley, Here’s your manuscript with all the edits I would recommend. Please review and let me know if you have any questions. I also added a couple tasks for you about things you should think about, as you figure out the rest of your story.
     </Boxel::ThreadMessage>
@@ -62,16 +61,9 @@
     <Args.Bool
       @name="fullWidth"
       @value={{this.fullWidth}}
-      @description="Whether to allocate the full width to the content. This only works if containsCard is also true"
+      @description="Whether to allocate the full width to the content"
       @defaultValue={{false}}
       @onInput={{fn (mut this.fullWidth)}}
-    />
-    <Args.Bool
-      @name="containsCard"
-      @value={{this.containsCard}}
-      @description="Whether or not the ThreadMessage contains a card as its first child. This modifies some layout rules for the message meta."
-      @defaultValue={{false}}
-      @onInput={{fn (mut this.containsCard)}}
     />
   </:api>
 </Freestyle::Usage>
@@ -97,46 +89,111 @@
 </Freestyle::Usage>
 
 <Freestyle::Usage
-  @description="Layout rules displayed"
+  @slug="with-cards"
 >
+  <:description>
+    <p>
+      The examples with embedded cards below are using the <code>@fullWidth</code> argument to
+      have access to the full-width content area. Smaller cards have a left margin the size of
+      <code>var(--boxel-thread-message-margin-left)</code> css variable for alignment.
+    </p>
+    <p>
+      Using the <code>@fullWidth</code> argument:
+      <ul>
+        <li>Allows the content to have access to the full-width content area</li>
+        <li>Adds spacing between the timestamp and the content</li>
+        <li>Vertically centers the timestamp in relation to the avatar</li>
+      </ul>
+    </p>
+    <p>
+      (Note: The messages below also have custom css applied which restricts their max-width. See <code>usage.css</code> file.)
+    </p>
+  </:description>
   <:example>
-    <div>
+    <div class="thread-message-usage">
       <Boxel::ThreadMessage
         @name="Cardbot"
+        @hideName={{true}}
         @imgURL={{this.cardbotIcon}}
       >
-        First thread message does not apply margins.
+        <p class="thread-message-usage__content">
+          Hello, it’s nice to see you!
+        </p>
       </Boxel::ThreadMessage>
       <Boxel::ThreadMessage
         @name="Cardbot"
-        @imgURL={{this.cardbotIcon}}
+        @hideName={{true}}
         @hideMeta={{true}}
+        @imgURL={{this.cardbotIcon}}
       >
-        A message with meta hidden has a margin-top of 1.25rem. 
+        <p class="thread-message-usage__content">
+          Let’s issue a Prepaid Card.
+        </p>
       </Boxel::ThreadMessage>
       <Boxel::ThreadMessage
         @name="Cardbot"
+        @hideName={{true}}
         @imgURL={{this.cardbotIcon}}
       >
-        A message without meta hidden has a margin-top of 2.5rem. 
+        <p class="thread-message-usage__content">
+          Let’s get down to business. Please choose the asset you would like
+          to deposit into the CARD Protocol’s reserve pool.
+        </p>
       </Boxel::ThreadMessage>
       <Boxel::ThreadMessage
         @name="Cardbot"
-        @imgURL={{this.cardbotIcon}}
+        @hideName={{true}}
         @hideMeta={{true}}
-      >
-        The following message which contains a card will have its meta centered relative to its avatar.
-      </Boxel::ThreadMessage>
-      <Boxel::ThreadMessage
-        @name="Cardbot"
         @imgURL={{this.cardbotIcon}}
-        @containsCard={{true}}
-        @fullWidth={{this.layoutExampleFullWidth}}
+        @fullWidth={{true}}
       >
-        <Boxel::CardContainer 
-          class="thread-message-usage-card"
+        <Boxel::CardContainer
+          class={{cn
+            "thread-message-usage__card"
+            thread-message-usage__card--memorialized=this.isComplete
+          }}
         >
-          <Boxel::Button @kind="primary" {{on "click" this.toggleLayoutExampleFullWidth}}>Click to toggle @fullWidth</Boxel::Button>
+          <Boxel::Header @header="Card 1" />
+          <p>Card 1 Content...</p>
+          <Boxel::ActionChin
+            @mode={{if this.isComplete "memorialized" "data-entry"}}
+            @buttonText="Click to toggle card width"
+            @onClickButton={{this.toggleIsComplete}}
+          />
+        </Boxel::CardContainer>
+      </Boxel::ThreadMessage>
+      <Boxel::ThreadMessage
+        @name="Cardbot"
+        @hideName={{true}}
+        @imgURL={{this.cardbotIcon}}
+        @fullWidth={{true}}
+      >
+        <Boxel::CardContainer
+          class="thread-message-usage__card thread-message-usage__card--memorialized"
+        >
+          <Boxel::Header @header="Card 2" />
+          <p>Card 2 Content...</p>
+        </Boxel::CardContainer>
+      </Boxel::ThreadMessage>
+      <Boxel::ThreadMessage
+        @name="Cardbot"
+        @hideName={{true}}
+        @imgURL={{this.cardbotIcon}}
+        @fullWidth={{true}}
+      >
+        <Boxel::CardContainer
+          class={{cn
+            "thread-message-usage__card"
+            thread-message-usage__card--memorialized=this.layoutExampleFullWidth
+          }}
+        >
+          <Boxel::Header @header="Card 3" />
+          <p>Card 3 Content...</p>
+          <Boxel::ActionChin
+            @mode={{if this.layoutExampleFullWidth "memorialized" "data-entry"}}
+            @buttonText="Click to toggle card width"
+            @onClickButton={{this.toggleLayoutExampleFullWidth}}
+          />
         </Boxel::CardContainer>
       </Boxel::ThreadMessage>
     </div>

--- a/addon/components/boxel/thread-message/usage.ts
+++ b/addon/components/boxel/thread-message/usage.ts
@@ -19,10 +19,12 @@ export default class ThreadMessageUsageComponent extends Component {
     'First, you can choose the look and feel of your card, so that your customers and other users recognize that this Prepaid Card came from you.',
   ]);
   @tracked fullWidth = false;
-  @tracked containsCard = false;
-
-  @tracked layoutExampleFullWidth = true;
+  @tracked layoutExampleFullWidth = false;
   @action toggleLayoutExampleFullWidth(): void {
     this.layoutExampleFullWidth = !this.layoutExampleFullWidth;
+  }
+  @tracked isComplete = false;
+  @action toggleIsComplete(): void {
+    this.isComplete = !this.isComplete;
   }
 }

--- a/addon/components/boxel/thread-message/usage.ts
+++ b/addon/components/boxel/thread-message/usage.ts
@@ -4,6 +4,7 @@ import { A } from '@ember/array';
 
 import LolaSampsonThumb from '@cardstack/boxel/usage-support/images/users/Lola-Sampson.jpg';
 import CardBot from '@cardstack/boxel/usage-support/images/orgs/cardbot.svg';
+import { action } from '@ember/object';
 
 export default class ThreadMessageUsageComponent extends Component {
   cardbotIcon = CardBot;
@@ -17,4 +18,11 @@ export default class ThreadMessageUsageComponent extends Component {
     'Let’s issue a Prepaid Card.',
     'First, you can choose the look and feel of your card, so that your customers and other users recognize that this Prepaid Card came from you.',
   ]);
+  @tracked fullWidth = false;
+  @tracked containsCard = false;
+
+  @tracked layoutExampleFullWidth = true;
+  @action toggleLayoutExampleFullWidth(): void {
+    this.layoutExampleFullWidth = !this.layoutExampleFullWidth;
+  }
 }

--- a/addon/components/boxel/thread/index.css
+++ b/addon/components/boxel/thread/index.css
@@ -6,8 +6,6 @@
   background-color: var(--boxel-light-300);
   border-radius: var(--boxel-border-radius);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
-  font: var(--boxel-font-sm);
-  letter-spacing: var(--boxel-lsp);
 }
 
 .boxel-thread__content-wrapper {
@@ -38,7 +36,7 @@
 }
 
 .boxel-thread__content > * + * {
-  margin-top: var(--boxel-sp-lg);
+  margin-top: var(--boxel-sp-xl);
 }
 
 .boxel-thread__sidebar {

--- a/tests/dummy/app/components/card-pay/workflow-thread/index.css
+++ b/tests/dummy/app/components/card-pay/workflow-thread/index.css
@@ -14,3 +14,8 @@
   letter-spacing: var(--boxel-lsp);
   text-align: center;
 }
+
+.card-pay-workflow-thread__message {
+  margin: 0;
+  max-width: 585px;
+}

--- a/tests/dummy/app/components/card-pay/workflow-thread/index.hbs
+++ b/tests/dummy/app/components/card-pay/workflow-thread/index.hbs
@@ -22,6 +22,7 @@
                     @imgURL={{@workflowBot.imgURL}}
                     @datetime={{milestone.datetime}}
                     @hideMeta={{gt i 0}}
+                    @fullWidth={{content.component}}
                   >
                     {{#if content.component}}
                       {{!-- Sample component --}}
@@ -34,7 +35,7 @@
                         @onClickButton={{fn this.toggleComplete milestone}}
                       />
                     {{else}}
-                      {{content}}
+                      <p class="card-pay-workflow-thread__message">{{content}}</p>
                     {{/if}}
                   </Boxel::ThreadMessage>
                 {{/animated-each}}


### PR DESCRIPTION
CS-638

Restructures layout of thread message component to follow design specs for workflows in Card Pay.

Adds two new arguments to thread messages to accommodate for cards + differences in space allocated between memorialized and default state cards:
- `@containsCard` - whether the thread message contains a card or not.
- `@fullWidth` - whether to allocate the full width to the card. Only works if `@containsCard` is true. This is for default state cards/cards that require action.

![image](https://user-images.githubusercontent.com/39579264/116233528-fd7d3280-a78d-11eb-8798-febcefe0cc94.png)