### PR TITLE
fix customradio example event listener

### DIFF
--- a/addon/components/boxel/custom-radio/usage.hbs
+++ b/addon/components/boxel/custom-radio/usage.hbs
@@ -1,13 +1,12 @@
 <Freestyle::Usage @name="CustomRadio" @description="A custom radio button component with some accessibility considerations built in">
     <:example>
       <Boxel::CustomRadio @groupDescription={{this.groupDescription}} @items={{this.items}} @checkedId={{this.checkedId}} @disabled={{this.disabled}} as |item|>
-          <item.component 
-            @id={{item.data.id}} 
+          <item.component  
             @name="example-radio-usage" 
             @checked={{item.checked}}
             @focusedClass="custom-radio-usage-red"
             @checkedClass="custom-radio-usage-big"
-            @onChange={{this.onChange}}
+            @onChange={{fn this.onChange item.data.id}}
           >
               {{item.data.id}}
           </item.component>
@@ -52,13 +51,13 @@
     <:example>
     <Boxel::CustomRadio::Container @groupDescription="Example Radio Usage">
       <Boxel::CustomRadio::Item
-        @id="radio-1"
+        id="radio-1"
         @name="radio-usage"
       >
         Item 1
       </Boxel::CustomRadio::Item>
       <Boxel::CustomRadio::Item
-        @id="radio-2"
+        id="radio-2"
         @name="radio-usage"
       >
         Item 2
@@ -76,27 +75,3 @@
       />
     </:api>
 </Freestyle::Usage>
-
-{{!-- 
-<Freestyle::Usage @name="CustomRadio::Item" @description>
-  <:example>
-    <Boxel::CustomRadio::Item
-      @id={{this.radioId}}
-      @name={{this.radioName}}
-      @value={{this.radioValue}}
-      @checked={{this.radioChecked}}
-      @onChange={{this.onChange}}
-    >
-      I've got custom checked styles
-    </Boxel::CustomRadio::Item>
-    <Boxel::CustomRadio::Item
-      @id={{this.radioId}}
-      @name={{this.radioName}}
-      @value={{this.radioValue}}
-      @checked={{this.radioChecked}}
-      @onChange={{this.onChange}}
-    >
-      I've got custom focus styles
-    </Boxel::CustomRadio::Item>
-  </:example>
-</Freestyle::Usage> --}}

--- a/addon/components/boxel/custom-radio/usage.ts
+++ b/addon/components/boxel/custom-radio/usage.ts
@@ -23,7 +23,7 @@ export default class CustomRadioUsage extends Component {
   @tracked checkedId = 'strawberry';
   @tracked disabled = false;
 
-  @action onChange(event: Event): void {
-    this.checkedId = (event.target as HTMLInputElement).id;
+  @action onChange(id: string): void {
+    this.checkedId = id;
   }
 }


### PR DESCRIPTION
The `@id` argument is no longer used in the custom radio, and the event listener should be updated to reflect this.