### PR TITLE
Enhancement/milestone banner status text option

### DIFF
--- a/addon/components/boxel/custom-radio/item/index.css
+++ b/addon/components/boxel/custom-radio/item/index.css
@@ -4,6 +4,7 @@
 */
 .boxel-custom-radio__label {
   display: block;
+  position: relative;
 }
 
 /* https://css-tricks.com/customise-radio-buttons-without-compromising-accessibility/ */

--- a/addon/components/boxel/milestone-banner/index.hbs
+++ b/addon/components/boxel/milestone-banner/index.hbs
@@ -1,4 +1,4 @@
 <div class="boxel-milestone-banner" ...attributes>
   <span class="boxel-milestone-banner__title">{{@title}}</span>
-  <span class="boxel-milestone-banner__status">Milestone Reached</span>
+  <span class="boxel-milestone-banner__status">{{@status}}</span>
 </div>

--- a/addon/components/boxel/milestone-banner/usage.hbs
+++ b/addon/components/boxel/milestone-banner/usage.hbs
@@ -1,6 +1,6 @@
 <Freestyle::Usage @name="MilestoneBanner">
   <:example>
-    <Boxel::MilestoneBanner @title={{this.title}} />
+    <Boxel::MilestoneBanner @title={{this.title}} @status={{this.status}} />
   </:example>
   <:api as |Args|>
     <Args.String
@@ -8,6 +8,12 @@
       @value={{this.title}}
       @description="The milestone title"
       @onInput={{fn (mut this.title)}}
+    />
+    <Args.String
+      @name="status"
+      @value={{this.status}}
+      @description="The milestone status"
+      @onInput={{fn (mut this.status)}}
     />
   </:api>
 </Freestyle::Usage>

--- a/addon/components/boxel/milestone-banner/usage.ts
+++ b/addon/components/boxel/milestone-banner/usage.ts
@@ -3,4 +3,5 @@ import { tracked } from '@glimmer/tracking';
 
 export default class extends Component {
   @tracked title = 'Layout customized';
+  @tracked status = 'Milestone reached';
 }


### PR DESCRIPTION
CS-848

Not providing fallback text for status, since this can be decided on a project-by-project basis, and having a fallback will interfere with us choosing not to show any status.