### PR TITLE
Input field optional and error states styling

### DIFF
--- a/addon/components/boxel/field/edit/index.css
+++ b/addon/components/boxel/field/edit/index.css
@@ -4,7 +4,7 @@
   display: grid;
   grid-template-columns: var(--boxel-field-label-width) 1fr;
   align-items: center;
-  gap: var(--boxel-sp-sm) var(--boxel-sp-lg);
+  column-gap: var(--boxel-sp-lg);
 }
 
 .boxel-edit-field__label {

--- a/addon/components/boxel/field/usage.hbs
+++ b/addon/components/boxel/field/usage.hbs
@@ -8,7 +8,10 @@
       style={{css-var boxel-field-label-width=this.labelWidth}}
     >
       {{#if (eq this.mode "edit")}}
-        <Boxel::Input @value={{this.value}} />
+        <Boxel::Input
+          @value={{this.value}}
+          @required={{true}}
+        />
       {{else}}
         {{this.value}}
       {{/if}}

--- a/addon/components/boxel/input/index.css
+++ b/addon/components/boxel/input/index.css
@@ -11,14 +11,51 @@
   transition: border-color var(--boxel-transition);
 }
 
-.boxel-input:hover {
+.boxel-input:disabled {
+  background-color: var(--boxel-light);
+  border-color: var(--boxel-purple-300);
+  color: rgba(0, 0, 0, 0.5);
+  opacity: 0.5;
+}
+
+.boxel-input:hover:not(:disabled) {
   border-color: var(--boxel-dark);
 }
 
-.boxel-input:disabled {
-  background-color: var(--boxel-light-100);
-  border-color: var(--boxel-purple-300);
-  color: var(--boxel-purple-300);
+.boxel-input--invalid {
+  border-color: var(--boxel-error-100);
+  box-shadow: 0 0 0 1px var(--boxel-error-100);
 }
 
-/* TODO: required and disabled styles */
+.boxel-input--invalid:hover:not(:disabled) {
+  border-color: var(--boxel-error-100);
+}
+
+.boxel-input__optional {
+  grid-row: 1;
+  grid-column: 1 / -1;
+  margin-bottom: var(--boxel-sp-xxxs);
+  color: rgba(0, 0, 0, 0.75);
+  font: var(--boxel-font-sm);
+  font-style: oblique;
+  letter-spacing: var(--boxel-lsp);
+  text-align: right;
+}
+
+.boxel-input__error-message {
+  grid-column: 2;
+  margin-top: var(--boxel-sp-xs);
+  margin-left: var(--boxel-sp-xs);
+  color: var(--boxel-error-100);
+  font: var(--boxel-font-sm);
+  letter-spacing: var(--boxel-lsp);
+}
+
+.boxel-input__helper-text {
+  grid-column: 2;
+  margin-top: var(--boxel-sp-xs);
+  margin-left: var(--boxel-sp-xs);
+  color: rgba(0, 0, 0, 0.75);
+  font: var(--boxel-font-sm);
+  letter-spacing: var(--boxel-lsp);
+}

--- a/addon/components/boxel/input/index.hbs
+++ b/addon/components/boxel/input/index.hbs
@@ -11,7 +11,7 @@
       required={{@required}}
       disabled={{@disabled}}
       aria-describedby={{if @helperText (concat "helper-text-" helperId) false}}
-      aria-invalid={{if @invalid true false}}
+      aria-invalid={{if @invalid "true"}}
       aria-errormessage={{if shouldShowErrorMessage (concat "error-message-" helperId) false}}
       data-test-boxel-input
       data-test-boxel-input-id={{@id}}

--- a/addon/components/boxel/input/index.hbs
+++ b/addon/components/boxel/input/index.hbs
@@ -1,23 +1,27 @@
 {{#if (and (not @required) @optional)}}
   <div class="boxel-input__optional">Optional</div>
 {{/if}}
-<Input
-  class={{cn "boxel-input" boxel-input--invalid=@invalid}}
-  id={{@id}}
-  @value={{@value}}
-  {{on "input" (optional @onInput)}}
-  required={{@required}}
-  disabled={{@disabled}}
-  aria-describedby={{if @helperText (concat "helper-text-" @id) false}}
-  aria-invalid={{if @invalid true false}}
-  aria-errormessage={{if @errorMessage (concat "error-message-" @id) false}}
-  data-test-boxel-input
-  data-test-boxel-input-id={{@id}}
-  ...attributes
-/>
-{{#if @errorMessage}}
-  <div id={{concat "error-message-" @id}} class="boxel-input__error-message">{{@errorMessage}}</div>
-{{/if}}
-{{#if @helperText}}
-  <div id={{concat "helper-text-" @id}} class="boxel-input__helper-text">{{@helperText}}</div>
-{{/if}}
+{{#let (and @invalid @errorMessage) as |shouldShowErrorMessage|}}
+  {{#let (unique-id) as |helperId|}}
+    <Input
+      class={{cn "boxel-input" boxel-input--invalid=@invalid}}
+      id={{@id}}
+      @value={{@value}}
+      {{on "input" (optional @onInput)}}
+      required={{@required}}
+      disabled={{@disabled}}
+      aria-describedby={{if @helperText (concat "helper-text-" helperId) false}}
+      aria-invalid={{if @invalid true false}}
+      aria-errormessage={{if shouldShowErrorMessage (concat "error-message-" helperId) false}}
+      data-test-boxel-input
+      data-test-boxel-input-id={{@id}}
+      ...attributes
+    />
+    {{#if shouldShowErrorMessage}}
+      <div id={{concat "error-message-" helperId}} class="boxel-input__error-message" data-test-boxel-input-error-message>{{@errorMessage}}</div>
+    {{/if}}
+    {{#if @helperText}}
+      <div id={{concat "helper-text-" helperId}} class="boxel-input__helper-text" data-test-boxel-input-helper-text>{{@helperText}}</div>
+    {{/if}}
+  {{/let}}
+{{/let}}

--- a/addon/components/boxel/input/index.hbs
+++ b/addon/components/boxel/input/index.hbs
@@ -1,11 +1,23 @@
+{{#if (and (not @required) @optional)}}
+  <div class="boxel-input__optional">Optional</div>
+{{/if}}
 <Input
-  class="boxel-input"
+  class={{cn "boxel-input" boxel-input--invalid=@errorMessage}}
   id={{@id}}
   @value={{@value}}
   {{on "input" (optional @onInput)}}
   required={{@required}}
   disabled={{@disabled}}
+  aria-describedby={{if @helperText "helper-text" false}}
+  aria-invalid={{if @errorMessage true false}}
+  aria-errormessage={{if @errorMessage "error-message" false}}
   data-test-boxel-input
   data-test-boxel-input-id={{@id}}
   ...attributes
 />
+{{#if @errorMessage}}
+  <div id="error-message" class="boxel-input__error-message">{{@errorMessage}}</div>
+{{/if}}
+{{#if @helperText}}
+  <div id="helper-text" class="boxel-input__helper-text">{{@helperText}}</div>
+{{/if}}

--- a/addon/components/boxel/input/index.hbs
+++ b/addon/components/boxel/input/index.hbs
@@ -2,22 +2,22 @@
   <div class="boxel-input__optional">Optional</div>
 {{/if}}
 <Input
-  class={{cn "boxel-input" boxel-input--invalid=@errorMessage}}
+  class={{cn "boxel-input" boxel-input--invalid=@invalid}}
   id={{@id}}
   @value={{@value}}
   {{on "input" (optional @onInput)}}
   required={{@required}}
   disabled={{@disabled}}
-  aria-describedby={{if @helperText "helper-text" false}}
-  aria-invalid={{if @errorMessage true false}}
-  aria-errormessage={{if @errorMessage "error-message" false}}
+  aria-describedby={{if @helperText (concat "helper-text-" @id) false}}
+  aria-invalid={{if @invalid true false}}
+  aria-errormessage={{if @errorMessage (concat "error-message-" @id) false}}
   data-test-boxel-input
   data-test-boxel-input-id={{@id}}
   ...attributes
 />
 {{#if @errorMessage}}
-  <div id="error-message" class="boxel-input__error-message">{{@errorMessage}}</div>
+  <div id={{concat "error-message-" @id}} class="boxel-input__error-message">{{@errorMessage}}</div>
 {{/if}}
 {{#if @helperText}}
-  <div id="helper-text" class="boxel-input__helper-text">{{@helperText}}</div>
+  <div id={{concat "helper-text-" @id}} class="boxel-input__helper-text">{{@helperText}}</div>
 {{/if}}

--- a/addon/components/boxel/input/usage.hbs
+++ b/addon/components/boxel/input/usage.hbs
@@ -8,6 +8,7 @@
       @disabled={{this.disabled}}
       @required={{this.required}}
       @optional={{this.optional}}
+      @invalid={{this.invalid}}
       @errorMessage={{this.errorMessage}}
       @helperText={{this.helperText}}
       {{on "blur" this.validate}}
@@ -39,6 +40,11 @@
       @value={{this.optional}}
       @onInput={{fn (mut this.optional)}}
       @description="Displays 'optional' label, unless the `@required` arg is also true"
+    />
+    <Args.String
+      @name="invalid"
+      @value={{this.invalid}}
+      @onInput={{fn (mut this.invalid)}}
     />
     <Args.String
       @name="errorMessage"

--- a/addon/components/boxel/input/usage.hbs
+++ b/addon/components/boxel/input/usage.hbs
@@ -41,7 +41,7 @@
       @onInput={{fn (mut this.optional)}}
       @description="Displays 'optional' label, unless the `@required` arg is also true"
     />
-    <Args.String
+    <Args.Bool
       @name="invalid"
       @value={{this.invalid}}
       @onInput={{fn (mut this.invalid)}}
@@ -50,6 +50,7 @@
       @name="errorMessage"
       @value={{this.errorMessage}}
       @onInput={{fn (mut this.errorMessage)}}
+      @description="This will only show up if the `@invalid` arg returns true"
     />
     <Args.String
       @name="helperText"

--- a/addon/components/boxel/input/usage.hbs
+++ b/addon/components/boxel/input/usage.hbs
@@ -4,9 +4,13 @@
     <Boxel::Input
       @id={{this.id}}
       @value={{this.value}}
-      @onInput={{@onInput}}
+      @onInput={{this.validate}}
       @disabled={{this.disabled}}
       @required={{this.required}}
+      @optional={{this.optional}}
+      @errorMessage={{this.errorMessage}}
+      @helperText={{this.helperText}}
+      {{on "blur" this.validate}}
     />
   </:example>
   <:api as |Args|>
@@ -29,6 +33,22 @@
       @name="required"
       @value={{this.required}}
       @onInput={{fn (mut this.required)}}
+    />
+    <Args.Bool
+      @name="optional"
+      @value={{this.optional}}
+      @onInput={{fn (mut this.optional)}}
+      @description="Displays 'optional' label, unless the `@required` arg is also true"
+    />
+    <Args.String
+      @name="errorMessage"
+      @value={{this.errorMessage}}
+      @onInput={{fn (mut this.errorMessage)}}
+    />
+    <Args.String
+      @name="helperText"
+      @value={{this.helperText}}
+      @onInput={{fn (mut this.helperText)}}
     />
     <Args.Action
       @name="onInput"

--- a/addon/components/boxel/input/usage.ts
+++ b/addon/components/boxel/input/usage.ts
@@ -1,9 +1,26 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 
 export default class extends Component {
   @tracked id = 'sample-input';
-  @tracked value = 'Hello Boxel';
+  @tracked value = '';
   @tracked disabled = false;
   @tracked required = false;
+  @tracked optional = false;
+  @tracked errorMessage = '';
+  @tracked helperText = '';
+
+  @action validate(ev: Event): void {
+    let target = ev.target as HTMLInputElement;
+    if (!target.validity?.valid) {
+      if (target.validity?.valueMissing) {
+        this.errorMessage = 'This is a required field';
+      } else {
+        this.errorMessage = target.validationMessage;
+      }
+      return;
+    }
+    this.errorMessage = '';
+  }
 }

--- a/addon/components/boxel/input/usage.ts
+++ b/addon/components/boxel/input/usage.ts
@@ -8,12 +8,14 @@ export default class extends Component {
   @tracked disabled = false;
   @tracked required = false;
   @tracked optional = false;
+  @tracked invalid = false;
   @tracked errorMessage = '';
   @tracked helperText = '';
 
   @action validate(ev: Event): void {
     let target = ev.target as HTMLInputElement;
     if (!target.validity?.valid) {
+      this.invalid = true;
       if (target.validity?.valueMissing) {
         this.errorMessage = 'This is a required field';
       } else {
@@ -21,6 +23,7 @@ export default class extends Component {
       }
       return;
     }
+    this.invalid = false;
     this.errorMessage = '';
   }
 }

--- a/addon/components/boxel/searchbox/index.css
+++ b/addon/components/boxel/searchbox/index.css
@@ -25,14 +25,6 @@
   font: var(--boxel-font-sm);
 }
 
-.boxel-searchbox__input-label {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  color: transparent;
-  background: transparent;
-}
-
 .boxel-searchbox__input::placeholder {
   color: var(--boxel-searchbox-text-color);
 }

--- a/addon/components/boxel/searchbox/index.hbs
+++ b/addon/components/boxel/searchbox/index.hbs
@@ -1,13 +1,14 @@
+{{#let (unique-id) as |inputId|}}
 <div class="boxel-searchbox" ...attributes>
     {{svg-jar "search" class="boxel-searchbox__search-icon"}}
-    {{#if (and @id @label)}}
-      <label for={{@id}} class="boxel-searchbox__input-label">{{@label}}</label>
+    {{#if @label}}
+      <label for={{or @id inputId}} class="boxel-sr-only">{{@label}}</label>
     {{/if}}
     {{!-- TODO: review accessibility of type=text vs type=search --}}
     <Input
       @type="text"
       class="boxel-searchbox__input"
-      id={{@id}}
+      id={{or @id inputId}}
       @value={{@value}}
       {{on "input" (optional @onInput)}}
       {{on "change" (optional @onChange)}}
@@ -15,3 +16,4 @@
       placeholder={{@placeholder}}
     />
 </div>
+{{/let}}

--- a/addon/components/boxel/text-field/index.hbs
+++ b/addon/components/boxel/text-field/index.hbs
@@ -12,6 +12,10 @@
       @onInput={{@onInput}}
       @disabled={{@disabled}}
       @required={{@required}}
+      @optional={{@optional}}
+      @invalid={{@invalid}}
+      @helperText={{@helperText}}
+      @errorMessage={{@errorMessage}}
       ...attributes
     />
   {{else}}

--- a/addon/components/boxel/text-field/usage.hbs
+++ b/addon/components/boxel/text-field/usage.hbs
@@ -9,6 +9,10 @@
       @onInput={{@onInput}}
       @disabled={{this.disabled}}
       @required={{this.required}}
+      @optional={{this.optional}}
+      @invalid={{this.invalid}}
+      @errorMessage={{this.errorMessage}}
+      @helperText={{this.helperText}}
     />
   </:example>
   <:api as |Args|>
@@ -52,6 +56,28 @@
       @name="required"
       @value={{this.required}}
       @onInput={{fn (mut this.required)}}
+    />
+    <Args.Bool
+      @name="optional"
+      @value={{this.optional}}
+      @onInput={{fn (mut this.optional)}}
+      @description="Displays 'optional' label, unless the `@required` arg is also true"
+    />
+    <Args.Bool
+      @name="invalid"
+      @value={{this.invalid}}
+      @onInput={{fn (mut this.invalid)}}
+    />
+    <Args.String
+      @name="errorMessage"
+      @value={{this.errorMessage}}
+      @onInput={{fn (mut this.errorMessage)}}
+      @description="This will only show up if the `@invalid` arg returns true"
+    />
+    <Args.String
+      @name="helperText"
+      @value={{this.helperText}}
+      @onInput={{fn (mut this.helperText)}}
     />
     <Args.Action
       @name="onInput"

--- a/addon/components/boxel/text-field/usage.ts
+++ b/addon/components/boxel/text-field/usage.ts
@@ -7,4 +7,8 @@ export default class extends Component {
   @tracked mode = 'edit';
   @tracked id = 'sample-field';
   @tracked labelClass = 'custom-classname';
+  @tracked optional = false;
+  @tracked invalid = false;
+  @tracked errorMessage = '';
+  @tracked helperText = '';
 }

--- a/addon/styles/variables.css
+++ b/addon/styles/variables.css
@@ -90,7 +90,7 @@
   --boxel-pink: #ff009d;
 
   /* Status colors */
-  --boxel-error-100: var(--boxel-red);    /* alert - attention - error */
+  --boxel-error-100: #f00;    /* alert - attention - error */
   --boxel-warning-100: var(--boxel-yellow); /* warning - notification */
   --boxel-success-100: var(--boxel-green);
   --boxel-success-200: var(--boxel-teal);

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "ember-template-lint": "^3.2.0",
     "ember-toolbars": "^0.6.0",
     "ember-try": "^1.4.0",
+    "ember-unique-id-helper-polyfill": "^0.1.0",
     "eslint": "^7.20.0",
     "eslint-config-prettier": "^7.1.0",
     "eslint-plugin-ember": "^10.1.1",

--- a/tests/integration/components/boxel/input-test.js
+++ b/tests/integration/components/boxel/input-test.js
@@ -58,4 +58,55 @@ module('Integration | Component | Input', function (hooks) {
     await fillIn('[data-test-boxel-input]', 'Ice-cream');
     assert.dom('[data-test-boxel-input]').hasValue('Ice-cream with puppies');
   });
+
+  test('It adds appropriate aria and ids to input helper and error text', async function (assert) {
+    await render(
+      hbs`<Boxel::Input @invalid={{true}} @errorMessage="Error message" @helperText="Helper text" />`
+    );
+
+    const errorMessageId = this.element.querySelector(
+      '[data-test-boxel-input-error-message]'
+    ).id;
+    const helperTextId = this.element.querySelector(
+      '[data-test-boxel-input-helper-text]'
+    ).id;
+
+    assert
+      .dom('[data-test-boxel-input]')
+      .hasAria('errormessage', errorMessageId);
+    assert.dom('[data-test-boxel-input]').hasAria('describedby', helperTextId);
+  });
+
+  test('It only shows the error message when there is one and the input state is invalid', async function (assert) {
+    this.set('invalid', false);
+    this.set('errorMessage', 'Error message');
+
+    await render(
+      hbs`<Boxel::Input @invalid={{this.invalid}} @errorMessage={{this.errorMessage}}/>`
+    );
+
+    assert.dom('[data-test-boxel-input]').doesNotHaveAria('invalid');
+    assert.dom('[data-test-boxel-input]').doesNotHaveAria('errormessage');
+    assert.dom('[data-test-boxel-input-error-message]').doesNotExist();
+
+    this.set('invalid', true);
+
+    const errorMessageId = this.element.querySelector(
+      '[data-test-boxel-input-error-message]'
+    ).id;
+
+    assert.dom('[data-test-boxel-input]').hasAria('invalid', '');
+    assert
+      .dom('[data-test-boxel-input]')
+      .hasAria('errormessage', errorMessageId);
+    assert
+      .dom('[data-test-boxel-input-error-message]')
+      .containsText('Error message');
+
+    this.set('errorMessage', '');
+
+    assert.dom('[data-test-boxel-input]').hasAria('invalid', '');
+    assert.dom('[data-test-boxel-input-error-message]').doesNotExist();
+    assert.dom('[data-test-boxel-input]').doesNotHaveAria('errormessage');
+  });
 });

--- a/tests/integration/components/boxel/input-test.js
+++ b/tests/integration/components/boxel/input-test.js
@@ -95,7 +95,7 @@ module('Integration | Component | Input', function (hooks) {
       '[data-test-boxel-input-error-message]'
     ).id;
 
-    assert.dom('[data-test-boxel-input]').hasAria('invalid', '');
+    assert.dom('[data-test-boxel-input]').hasAria('invalid', 'true');
     assert
       .dom('[data-test-boxel-input]')
       .hasAria('errormessage', errorMessageId);
@@ -105,7 +105,7 @@ module('Integration | Component | Input', function (hooks) {
 
     this.set('errorMessage', '');
 
-    assert.dom('[data-test-boxel-input]').hasAria('invalid', '');
+    assert.dom('[data-test-boxel-input]').hasAria('invalid', 'true');
     assert.dom('[data-test-boxel-input-error-message]').doesNotExist();
     assert.dom('[data-test-boxel-input]').doesNotHaveAria('errormessage');
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7731,6 +7731,14 @@ ember-try@^1.4.0:
     rsvp "^4.7.0"
     walk-sync "^1.1.3"
 
+ember-unique-id-helper-polyfill@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ember-unique-id-helper-polyfill/-/ember-unique-id-helper-polyfill-0.1.0.tgz#372f1272cd45dd3ee960a20a4945918264ff1bd3"
+  integrity sha512-qACD+lzMCOXRBJnJdA3tM1bHEKziVga2hhZGpTToLL8QlPj67+lwCaz+j6HBBA/Yw1yavVogO+NUwR8Q1iMKow==
+  dependencies:
+    ember-cli-babel "^7.23.0"
+    ember-cli-htmlbars "^5.3.1"
+
 ember-useragent@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/ember-useragent/-/ember-useragent-0.6.1.tgz#0854b3c11acf0fdd98a165fba9bf5dc76eace804"


### PR DESCRIPTION
CS-497

Adds `@helperText`, `@errorMessage`, `@optional` args to Boxel::Input component and their styling

<img width="902" alt="required-field" src="https://user-images.githubusercontent.com/16160806/119903582-e65d6c00-bf16-11eb-88d7-f1ad18fa14ef.png">
