### PR TITLE
fix stripped test selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ember-set-body-class": "^1.0.2",
     "ember-svg-jar": "^2.2.3",
     "ember-table": "^2.2.3",
-    "ember-test-selectors": "^2.1.0",
+    "ember-test-selectors": "^5.0.0",
     "ember-truth-helpers": "^3.0.0",
     "file-loader": "^6.2.0",
     "macro-decorators": "^0.1.2",
@@ -160,6 +160,9 @@
     "release-it-lerna-changelog": "^3.1.0",
     "stylelint-config-standard": "^21.0.0",
     "typescript": "^4.2.3"
+  },
+  "resolutions": {
+    "ember-test-selectors": "^5.0.0"
   },
   "engines": {
     "node": "12.* || >= 14.*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6952,7 +6952,7 @@ ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0, ember-cli-ve
     resolve "^1.3.3"
     semver "^5.3.0"
 
-ember-cli-version-checker@^3.0.0, ember-cli-version-checker@^3.0.1, ember-cli-version-checker@^3.1.2, ember-cli-version-checker@^3.1.3:
+ember-cli-version-checker@^3.0.0, ember-cli-version-checker@^3.0.1, ember-cli-version-checker@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz#7c9b4f5ff30fdebcd480b1c06c4de43bb51c522c"
   integrity sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==
@@ -7666,15 +7666,7 @@ ember-template-recast@^5.0.1:
     tmp "^0.2.1"
     workerpool "^6.0.3"
 
-ember-test-selectors@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ember-test-selectors/-/ember-test-selectors-2.1.0.tgz#faebdf06702aaa0bc510d55eb721ce54d2e85793"
-  integrity sha512-c5HmvefmeABH8hg380TSNZiE9VAK1CBeXWrgyXy+IXHtsew4lZHHw7GnqCAqsakxwvmaMARbAKY9KfSAE91s1g==
-  dependencies:
-    ember-cli-babel "^6.8.2"
-    ember-cli-version-checker "^3.1.2"
-
-ember-test-selectors@^5.0.0:
+ember-test-selectors@^2.1.0, ember-test-selectors@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ember-test-selectors/-/ember-test-selectors-5.0.0.tgz#36c30f64498039cb88797cdda682275a460ee624"
   integrity sha512-hqAPqyJLEGBYcQ9phOKvHhSCyvcSbUL8Yj2si8OASsQWxwRqbxrtk5YlkN2aZiZdp9PAd2wErS8uClG0U7tNpA==


### PR DESCRIPTION
Was trying to fix missing `data-test` selectors causing failing tests. Updating `ember-test-selectors` seems to work. We don't need to support older versions of `ember-test-selectors`. `ember-table` uses the old version (2.x) because it needs to support ember-source@2.8: https://github.com/Addepar/ember-table/pull/847, which we don't include in CI/CD.