### PR TITLE
Enhancement/disabled action chins

### DIFF
--- a/addon/components/boxel/action-chin/index.css
+++ b/addon/components/boxel/action-chin/index.css
@@ -46,12 +46,12 @@
   --boxel-action-chin-padding-vertical: var(--boxel-sp-xl);
 }
 
-.boxel-action-chin--memorialized.boxel-action-chin--has-step {
+.boxel-action-chin--memorialized.boxel-action-chin--has-step,
+.boxel-action-chin--disabled.boxel-action-chin--has-step {
   --boxel-action-chin-padding-vertical: var(--boxel-sp-xs);
 }
 
-.boxel-action-chin--disabled.boxel-action-chin--has-step {
-  --boxel-action-chin-padding-vertical: var(--boxel-sp-xs);
+.boxel-action-chin--default.boxel-action-chin--disabled.boxel-action-chin--has-step {
   --boxel-action-chin-background-color: var(--boxel-purple-700-opacity90);
 }
 

--- a/addon/components/boxel/action-chin/index.hbs
+++ b/addon/components/boxel/action-chin/index.hbs
@@ -2,6 +2,7 @@
   class={{cn
     "boxel-action-chin"
     (if @state (concat "boxel-action-chin--" @state))
+    (if @disabled "boxel-action-chin--disabled")
     (if @stepNumber (concat "boxel-action-chin--has-step"))
   }}
   ...attributes
@@ -13,39 +14,20 @@
       <span class="boxel-sr-only">Step {{@stepNumber}}</span>
     </div>
   {{/if}}
-  {{!--
-    We cannot pass splattribute classes to components in the component helper:
-    https://github.com/emberjs/ember.js/issues/18402
-  --}}
-  {{#if (and (has-block "disabled") this.isDisabled)}}
-    {{yield
-      (hash
-        ActionButton=(component
-          "boxel/button"
-          kind="primary"
-          disabled=true
-          class="boxel-action-chin__action-button"
-        )
-        InfoArea=(component
-          "boxel/action-chin/info-area"
-          class="boxel-action-chin__info-area"
-        )
-      )
-      to="disabled"
-    }}
-  {{else if (and (has-block "in-progress") this.isInProgress)}}
+  {{#if (and (has-block "in-progress") this.isInProgress)}}
     {{yield
       (hash
         ActionButton=(component
           "boxel/button"
           kind="primary"
           loading=true
-          disabled=this.isDisabled
+          disabled=@disabled
           class="boxel-action-chin__action-button"
         )
         CancelButton=(component
           "boxel/button"
           kind="secondary-dark"
+          disabled=@disabled
           class="boxel-action-chin__cancel-button"
         )
         ActionStatusArea=(component
@@ -68,7 +50,7 @@
         ActionButton=(component
           "boxel/button"
           kind="secondary-light"
-          disabled=this.isDisabled
+          disabled=@disabled
         )
         ActionStatusArea=(component
           "boxel/action-chin/action-status-area"
@@ -87,7 +69,7 @@
         ActionButton=(component
           "boxel/button"
           kind="primary"
-          disabled=this.isDisabled
+          disabled=@disabled
         )
         ActionStatusArea=(component
           "boxel/action-chin/action-status-area"
@@ -102,7 +84,7 @@
   {{/if}}
   {{!-- in any state except: disabled + has a step, we want the lock shown --}}
   {{!-- template-lint-disable simple-unless --}}
-  {{#unless (and this.isDisabled @stepNumber)}}
+  {{#unless (and @disabled @stepNumber)}}
     <span class="boxel-action-chin__private-notice" data-test-boxel-action-chin-private-notice>Actions only visible to you</span>
     {{svg-jar "lock" class="boxel-action-chin__lock-icon" role="presentation"}}
   {{/unless}}

--- a/addon/components/boxel/action-chin/index.ts
+++ b/addon/components/boxel/action-chin/index.ts
@@ -21,7 +21,6 @@ export default class ActionChin extends Component<ActionChinArguments> {
   // convenience getters for state booleans. they are mutually exclusive since all are
   // derived from the args.state argument.
   @equal('args.state', ActionChinState.default) declare isDefault: boolean;
-  @equal('args.state', ActionChinState.disabled) declare isDisabled: boolean;
   @equal('args.state', ActionChinState.inProgress)
   declare isInProgress: boolean;
   @equal('args.state', ActionChinState.memorialized)

--- a/addon/components/boxel/action-chin/usage.hbs
+++ b/addon/components/boxel/action-chin/usage.hbs
@@ -17,14 +17,6 @@
           Custom info area
         </a.InfoArea>
       </:default>
-      <:disabled as |d|>
-        <d.ActionButton>
-          Disabled
-        </d.ActionButton>
-        <d.InfoArea>
-          Custom info area
-        </d.InfoArea>
-      </:disabled>
       <:in-progress as |i|>
         <i.ActionButton>
           In-progress
@@ -49,7 +41,7 @@
   <:api as |Args|>
     <Args.String
       @name="state"
-      @description="Whether the action is at at rest, disabled, in progress, or memorialized."
+      @description="Whether the action is at at rest, in progress, or memorialized."
       @options={{array "default" "in-progress" "memorialized"}}
       @defaultValue="default"
       @value={{this.state}}
@@ -68,10 +60,6 @@
       @optional={{true}}
       @value={{this.stepNumber}}
       @onInput={{fn (mut this.stepNumber)}}
-    />
-    <Args.Yield
-      @name="disabled"
-      @description="The block shown when @state is 'disabled'. Yields { ActionButton, InfoArea }"
     />
     <Args.Yield
       @name="in-progress"
@@ -112,7 +100,6 @@
   <:description>
     <p>
       <code>ActionStatusArea</code> displays custom content in the action chin.
-      It can be used with any block except the <code>:disabled</code> named block.
       It accepts an <code>@icon</code> argument.
       In the <code>:memorialized</code> block, the icon is a checkmark by default.
     </p>
@@ -197,7 +184,6 @@
         <tbody>
           <tr><td>State</td><td>Explanation</td></tr>
           <tr><td>default</td> <td>When the user has not met the requirements for the cta to be considered done</td></tr>
-          <tr><td>disabled</td> <td>When the user cannot yet take this action</td></tr>
           <tr><td>in-progress</td> <td>When the action is in progress</td></tr>
           <tr><td>memorialized</td> <td>When the action is done</td></tr>
         </tbody>
@@ -228,7 +214,6 @@
             <td>
               <ul>
                 <li>default</li>
-                <li>disabled</li>
                 <li>memorialized</li>
                 <li>in-progress</li>
               </ul>
@@ -280,7 +265,6 @@
             <td>
               <ul>
                 <li>default</li>
-                <li>disabled</li>
                 <li>memorialized</li>
                 <li>in-progress</li>
               </ul>

--- a/addon/components/boxel/action-chin/usage.hbs
+++ b/addon/components/boxel/action-chin/usage.hbs
@@ -7,6 +7,7 @@
     <Boxel::ActionChin
       @stepNumber={{this.stepNumber}}
       @state={{this.state}}
+      @disabled={{this.disabled}}
     >
       <:default as |a|>
         <a.ActionButton>
@@ -49,10 +50,17 @@
     <Args.String
       @name="state"
       @description="Whether the action is at at rest, disabled, in progress, or memorialized."
-      @options={{array "default" "disabled" "in-progress" "memorialized"}}
+      @options={{array "default" "in-progress" "memorialized"}}
       @defaultValue="default"
       @value={{this.state}}
       @onInput={{fn (mut this.state)}}
+    />
+    <Args.Bool
+      @name="disabled"
+      @description="Whether the action chin is disabled. If state is default, will show the disabled named block if available."
+      @defaultValue={{false}}
+      @value={{this.disabled}}
+      @onInput={{fn (mut this.disabled)}}
     />
     <Args.Number
       @name="stepNumber"
@@ -155,7 +163,8 @@
     </Boxel::ActionChin>
     <Boxel::ActionChin
       @stepNumber={{2}}
-      @state={{if this.depositIsDisabled "disabled" this.depositState}}
+      @state={{this.depositState}}
+      @disabled={{this.depositIsDisabled}}
     >
       <:default as |a|>
         <a.ActionButton

--- a/addon/components/boxel/action-chin/usage.ts
+++ b/addon/components/boxel/action-chin/usage.ts
@@ -7,6 +7,7 @@ let inProgressTimeout: number;
 export default class ActionChinUsage extends Component {
   @tracked stepNumber = 0;
   @tracked state = 'default';
+  @tracked disabled = false;
   @tracked isComplete = false;
   @tracked unlockState = 'default';
   @tracked depositState = 'disabled';

--- a/tests/integration/components/boxel/action-chin-test.js
+++ b/tests/integration/components/boxel/action-chin-test.js
@@ -73,41 +73,6 @@ module('Integration | Component | ActionChin', function (hooks) {
     assert.dom(MAIN_ACTION_AREA_ICON_SELECTOR).doesNotExist();
   });
 
-  test('it accepts and renders the disabled named block with the ActionButton, and InfoArea components', async function (assert) {
-    this.setProperties({
-      state: 'disabled',
-      stepNumber: null,
-      mainActionButtonText,
-      infoAreaText,
-    });
-    await render(hbs`
-      <Boxel::ActionChin
-        @state={{this.state}}
-        @stepNumber={{this.stepNumber}}
-      >
-        <:disabled as |d|>
-          <d.ActionButton>
-            {{this.mainActionButtonText}}
-          </d.ActionButton>
-          <d.InfoArea>
-            {{this.infoAreaText}}
-          </d.InfoArea>
-        </:disabled>
-      </Boxel::ActionChin>
-    `);
-    assert.dom(MAIN_ACTION_BUTTON_SELECTOR).containsText(mainActionButtonText);
-    assert.dom(MAIN_ACTION_BUTTON_SELECTOR).isDisabled();
-    assert.dom(INFO_AREA_SELECTOR).containsText(infoAreaText);
-    assert.dom(MAIN_ACTION_AREA_SELECTOR).doesNotExist();
-
-    this.set('stepNumber', 1);
-    assert.dom(INFO_AREA_SELECTOR).containsText(infoAreaText);
-    assert.dom(DEFAULT_PRIVATE_NOTICE_SELECTOR).doesNotExist();
-
-    await a11yAudit();
-    assert.ok(true, 'no a11y errors found!');
-  });
-
   test('it accepts and renders the in-progress named block with the ActionButton, CancelButton, ActionStatusArea and InfoArea components', async function (assert) {
     this.setProperties({
       state: 'in-progress',
@@ -211,7 +176,6 @@ module('Integration | Component | ActionChin', function (hooks) {
   test('it changes rendered contents when @state argument changes', async function (assert) {
     const stateText = {
       default: 'Default state here',
-      disabled: 'Disabled state here',
       'in-progress': 'In progress state here',
       memorialized: 'Memorialized state here',
     };
@@ -226,9 +190,6 @@ module('Integration | Component | ActionChin', function (hooks) {
       <:default>
         {{get this.stateText "default"}}
       </:default>
-      <:disabled>
-        {{get this.stateText "disabled"}}
-      </:disabled>
       <:in-progress>
         {{get this.stateText "in-progress"}}
       </:in-progress>
@@ -237,7 +198,7 @@ module('Integration | Component | ActionChin', function (hooks) {
       </:memorialized>
       </Boxel::ActionChin>
     `);
-    const states = ['default', 'disabled', 'in-progress', 'memorialized'];
+    const states = ['default', 'in-progress', 'memorialized'];
     for (const state of states) {
       this.set('state', state);
       assert.dom(ACTION_CHIN_SELECTOR).containsText(stateText[state]);
@@ -327,5 +288,48 @@ module('Integration | Component | ActionChin', function (hooks) {
     assert.dom(DEFAULT_PRIVATE_NOTICE_SELECTOR).exists();
     this.set('state', 'memorialized');
     assert.dom(DEFAULT_PRIVATE_NOTICE_SELECTOR).exists();
+  });
+
+  test('It renders disabled buttons for disabled states', async function (assert) {
+    this.set('state', 'default');
+    await render(hbs`
+      <Boxel::ActionChin
+        @state={{this.state}}
+        @disabled={{true}}
+      >
+      <:default as |a|>
+        <a.ActionButton>
+          Default
+        </a.ActionButton>
+      </:default>
+      <:in-progress as |i|>
+        <i.ActionButton>
+          In Progress
+        </i.ActionButton>
+        <i.CancelButton>
+          Cancel
+        </i.CancelButton>
+      </:in-progress>
+      <:memorialized as |m|>
+        <m.ActionButton>
+          Memorialized
+        </m.ActionButton>
+      </:memorialized>
+      </Boxel::ActionChin>
+    `);
+
+    assert.dom(MAIN_ACTION_BUTTON_SELECTOR).containsText('Default');
+    assert.dom(MAIN_ACTION_BUTTON_SELECTOR).isDisabled();
+
+    this.set('state', 'memorialized');
+    assert.dom(MAIN_ACTION_BUTTON_SELECTOR).containsText('Memorialized');
+    assert.dom(MAIN_ACTION_BUTTON_SELECTOR).isDisabled();
+
+    this.set('state', 'in-progress');
+    assert.dom(MAIN_ACTION_BUTTON_SELECTOR).containsText('In Progress');
+    assert.dom(MAIN_ACTION_BUTTON_SELECTOR).isDisabled();
+    assert.dom(CANCEL_CTA).isDisabled();
+
+    assert.ok(true, 'No a11y errors for disabled states');
   });
 });


### PR DESCRIPTION
Work to support https://github.com/cardstack/cardstack/pull/1659

- Removes the disabled named block and state from the action chin
  - For all uses in the monorepo so far, the disabled named block is the same as the default block besides the button being disabled
  - Only exception is the styling for disabled action chins with steps
- Adds the `@disabled` argument that causes all contextual buttons from this component to be disabled by default, and styling for disabled action chins with steps to be applied
- Fixes some contrast issues in disabled action chins