### PR TITLE
Suggestion/unique id helper

### DIFF
--- a/addon/components/boxel/input/index.hbs
+++ b/addon/components/boxel/input/index.hbs
@@ -1,23 +1,25 @@
 {{#if (and (not @required) @optional)}}
   <div class="boxel-input__optional">Optional</div>
 {{/if}}
-<Input
-  class={{cn "boxel-input" boxel-input--invalid=@invalid}}
-  id={{@id}}
-  @value={{@value}}
-  {{on "input" (optional @onInput)}}
-  required={{@required}}
-  disabled={{@disabled}}
-  aria-describedby={{if @helperText (concat "helper-text-" @id) false}}
-  aria-invalid={{if @invalid true false}}
-  aria-errormessage={{if @errorMessage (concat "error-message-" @id) false}}
-  data-test-boxel-input
-  data-test-boxel-input-id={{@id}}
-  ...attributes
-/>
-{{#if @errorMessage}}
-  <div id={{concat "error-message-" @id}} class="boxel-input__error-message">{{@errorMessage}}</div>
-{{/if}}
-{{#if @helperText}}
-  <div id={{concat "helper-text-" @id}} class="boxel-input__helper-text">{{@helperText}}</div>
-{{/if}}
+{{#let (unique-id) as |helperId|}}
+  <Input
+    class={{cn "boxel-input" boxel-input--invalid=@invalid}}
+    id={{@id}}
+    @value={{@value}}
+    {{on "input" (optional @onInput)}}
+    required={{@required}}
+    disabled={{@disabled}}
+    aria-describedby={{if @helperText (concat "helper-text-" helperId) false}}
+    aria-invalid={{if @invalid true false}}
+    aria-errormessage={{if @errorMessage (concat "error-message-" helperId) false}}
+    data-test-boxel-input
+    data-test-boxel-input-id={{@id}}
+    ...attributes
+  />
+  {{#if @errorMessage}}
+    <div id={{concat "error-message-" helperId}} class="boxel-input__error-message">{{@errorMessage}}</div>
+  {{/if}}
+  {{#if @helperText}}
+    <div id={{concat "helper-text-" helperId}} class="boxel-input__helper-text">{{@helperText}}</div>
+  {{/if}}
+{{/let}}

--- a/addon/components/boxel/input/index.hbs
+++ b/addon/components/boxel/input/index.hbs
@@ -1,25 +1,27 @@
 {{#if (and (not @required) @optional)}}
   <div class="boxel-input__optional">Optional</div>
 {{/if}}
-{{#let (unique-id) as |helperId|}}
-  <Input
-    class={{cn "boxel-input" boxel-input--invalid=@invalid}}
-    id={{@id}}
-    @value={{@value}}
-    {{on "input" (optional @onInput)}}
-    required={{@required}}
-    disabled={{@disabled}}
-    aria-describedby={{if @helperText (concat "helper-text-" helperId) false}}
-    aria-invalid={{if @invalid true false}}
-    aria-errormessage={{if @errorMessage (concat "error-message-" helperId) false}}
-    data-test-boxel-input
-    data-test-boxel-input-id={{@id}}
-    ...attributes
-  />
-  {{#if @errorMessage}}
-    <div id={{concat "error-message-" helperId}} class="boxel-input__error-message">{{@errorMessage}}</div>
-  {{/if}}
-  {{#if @helperText}}
-    <div id={{concat "helper-text-" helperId}} class="boxel-input__helper-text">{{@helperText}}</div>
-  {{/if}}
+{{#let (and @invalid @errorMessage) as |shouldShowErrorMessage|}}
+  {{#let (unique-id) as |helperId|}}
+    <Input
+      class={{cn "boxel-input" boxel-input--invalid=@invalid}}
+      id={{@id}}
+      @value={{@value}}
+      {{on "input" (optional @onInput)}}
+      required={{@required}}
+      disabled={{@disabled}}
+      aria-describedby={{if @helperText (concat "helper-text-" helperId) false}}
+      aria-invalid={{if @invalid true false}}
+      aria-errormessage={{if shouldShowErrorMessage (concat "error-message-" helperId) false}}
+      data-test-boxel-input
+      data-test-boxel-input-id={{@id}}
+      ...attributes
+    />
+    {{#if shouldShowErrorMessage}}
+      <div id={{concat "error-message-" helperId}} class="boxel-input__error-message" data-test-boxel-input-error-message>{{@errorMessage}}</div>
+    {{/if}}
+    {{#if @helperText}}
+      <div id={{concat "helper-text-" helperId}} class="boxel-input__helper-text" data-test-boxel-input-helper-text>{{@helperText}}</div>
+    {{/if}}
+  {{/let}}
 {{/let}}

--- a/addon/components/boxel/searchbox/index.css
+++ b/addon/components/boxel/searchbox/index.css
@@ -25,14 +25,6 @@
   font: var(--boxel-font-sm);
 }
 
-.boxel-searchbox__input-label {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  color: transparent;
-  background: transparent;
-}
-
 .boxel-searchbox__input::placeholder {
   color: var(--boxel-searchbox-text-color);
 }

--- a/addon/components/boxel/searchbox/index.hbs
+++ b/addon/components/boxel/searchbox/index.hbs
@@ -1,7 +1,7 @@
 <div class="boxel-searchbox" ...attributes>
     {{svg-jar "search" class="boxel-searchbox__search-icon"}}
     {{#if (and @id @label)}}
-      <label for={{@id}} class="boxel-searchbox__input-label">{{@label}}</label>
+      <label for={{@id}} class="boxel-sr-only">{{@label}}</label>
     {{/if}}
     {{!-- TODO: review accessibility of type=text vs type=search --}}
     <Input

--- a/addon/components/boxel/searchbox/index.hbs
+++ b/addon/components/boxel/searchbox/index.hbs
@@ -1,13 +1,14 @@
+{{#let (unique-id) as |inputId|}}
 <div class="boxel-searchbox" ...attributes>
     {{svg-jar "search" class="boxel-searchbox__search-icon"}}
-    {{#if (and @id @label)}}
-      <label for={{@id}} class="boxel-sr-only">{{@label}}</label>
+    {{#if @label}}
+      <label for={{or @id inputId}} class="boxel-sr-only">{{@label}}</label>
     {{/if}}
     {{!-- TODO: review accessibility of type=text vs type=search --}}
     <Input
       @type="text"
       class="boxel-searchbox__input"
-      id={{@id}}
+      id={{or @id inputId}}
       @value={{@value}}
       {{on "input" (optional @onInput)}}
       {{on "change" (optional @onChange)}}
@@ -15,3 +16,4 @@
       placeholder={{@placeholder}}
     />
 </div>
+{{/let}}

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "ember-template-lint": "^3.2.0",
     "ember-toolbars": "^0.6.0",
     "ember-try": "^1.4.0",
+    "ember-unique-id-helper-polyfill": "^0.1.0",
     "eslint": "^7.20.0",
     "eslint-config-prettier": "^7.1.0",
     "eslint-plugin-ember": "^10.1.1",

--- a/tests/integration/components/boxel/input-test.js
+++ b/tests/integration/components/boxel/input-test.js
@@ -58,4 +58,21 @@ module('Integration | Component | Input', function (hooks) {
     await fillIn('[data-test-boxel-input]', 'Ice-cream');
     assert.dom('[data-test-boxel-input]').hasValue('Ice-cream with puppies');
   });
+
+  test('It adds appropriate aria and ids to input helper and error text', async function (assert) {
+    await render(
+      hbs`<Boxel::Input @invalid={{true}} @errorMessage="Error message" @helperText="Helper text" />`
+    );
+
+    const errorMessageId = this.element.querySelector(
+      '.boxel-input__error-message'
+    ).id;
+    const helperTextId = this.element.querySelector('.boxel-input__helper-text')
+      .id;
+
+    assert
+      .dom('[data-test-boxel-input]')
+      .hasAria('errormessage', errorMessageId);
+    assert.dom('[data-test-boxel-input]').hasAria('describedby', helperTextId);
+  });
 });

--- a/tests/integration/components/boxel/input-test.js
+++ b/tests/integration/components/boxel/input-test.js
@@ -65,14 +65,48 @@ module('Integration | Component | Input', function (hooks) {
     );
 
     const errorMessageId = this.element.querySelector(
-      '.boxel-input__error-message'
+      '[data-test-boxel-input-error-message]'
     ).id;
-    const helperTextId = this.element.querySelector('.boxel-input__helper-text')
-      .id;
+    const helperTextId = this.element.querySelector(
+      '[data-test-boxel-input-helper-text]'
+    ).id;
 
     assert
       .dom('[data-test-boxel-input]')
       .hasAria('errormessage', errorMessageId);
     assert.dom('[data-test-boxel-input]').hasAria('describedby', helperTextId);
+  });
+
+  test('It only shows the error message when there is one and the input state is invalid', async function (assert) {
+    this.set('invalid', false);
+    this.set('errorMessage', 'Error message');
+
+    await render(
+      hbs`<Boxel::Input @invalid={{this.invalid}} @errorMessage={{this.errorMessage}}/>`
+    );
+
+    assert.dom('[data-test-boxel-input]').doesNotHaveAria('invalid');
+    assert.dom('[data-test-boxel-input]').doesNotHaveAria('errormessage');
+    assert.dom('[data-test-boxel-input-error-message]').doesNotExist();
+
+    this.set('invalid', true);
+
+    const errorMessageId = this.element.querySelector(
+      '[data-test-boxel-input-error-message]'
+    ).id;
+
+    assert.dom('[data-test-boxel-input]').hasAria('invalid', '');
+    assert
+      .dom('[data-test-boxel-input]')
+      .hasAria('errormessage', errorMessageId);
+    assert
+      .dom('[data-test-boxel-input-error-message]')
+      .containsText('Error message');
+
+    this.set('errorMessage', '');
+
+    assert.dom('[data-test-boxel-input]').hasAria('invalid', '');
+    assert.dom('[data-test-boxel-input-error-message]').doesNotExist();
+    assert.dom('[data-test-boxel-input]').doesNotHaveAria('errormessage');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7731,6 +7731,14 @@ ember-try@^1.4.0:
     rsvp "^4.7.0"
     walk-sync "^1.1.3"
 
+ember-unique-id-helper-polyfill@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ember-unique-id-helper-polyfill/-/ember-unique-id-helper-polyfill-0.1.0.tgz#372f1272cd45dd3ee960a20a4945918264ff1bd3"
+  integrity sha512-qACD+lzMCOXRBJnJdA3tM1bHEKziVga2hhZGpTToLL8QlPj67+lwCaz+j6HBBA/Yw1yavVogO+NUwR8Q1iMKow==
+  dependencies:
+    ember-cli-babel "^7.23.0"
+    ember-cli-htmlbars "^5.3.1"
+
 ember-useragent@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/ember-useragent/-/ember-useragent-0.6.1.tgz#0854b3c11acf0fdd98a165fba9bf5dc76eace804"


### PR DESCRIPTION
- Adds a unique-id helper that is described here: https://emberjs.github.io/rfcs/0659-unique-id-helper.html, via polyfill. Since we don't really enforce the usage of an id argument on inputs, and there is also the possibility of collision even if we assign ids, this helper ensures that assistive tech correctly identifies unique descriptive elements. 
- The input only shows the error message if it is invalid