### PR TITLE
add an autoscroll argument to the thread component

### DIFF
--- a/addon/components/boxel/thread/index.hbs
+++ b/addon/components/boxel/thread/index.hbs
@@ -4,7 +4,7 @@
   </div>
 
   <div class="boxel-thread__content-wrapper">
-    <div class="boxel-thread__scroll-wrapper" tabindex="0" {{autoscroll}}>
+    <div class="boxel-thread__scroll-wrapper" tabindex="0" {{autoscroll disable=(not @autoscroll)}}>
       <div class="boxel-thread__sticky-container">
         {{yield to="taskbar"}}
       </div>

--- a/addon/components/boxel/thread/index.hbs
+++ b/addon/components/boxel/thread/index.hbs
@@ -4,7 +4,7 @@
   </div>
 
   <div class="boxel-thread__content-wrapper">
-    <div class="boxel-thread__scroll-wrapper" tabindex="0" {{autoscroll disable=(not @autoscroll)}}>
+    <div class="boxel-thread__scroll-wrapper" tabindex="0" {{autoscroll enabled=@autoscroll}}>
       <div class="boxel-thread__sticky-container">
         {{yield to="taskbar"}}
       </div>

--- a/addon/components/boxel/thread/usage.css
+++ b/addon/components/boxel/thread/usage.css
@@ -1,0 +1,3 @@
+.boxel-thread-usage {
+  max-height: 300px;
+}

--- a/addon/components/boxel/thread/usage.hbs
+++ b/addon/components/boxel/thread/usage.hbs
@@ -1,22 +1,35 @@
 <Freestyle::Usage @name="Thread">
   <:example>
-    <Boxel::Thread>
+    <button {{on "click" this.addMessage}}>Add a message</button>
+    <Boxel::Thread @autoscroll={{this.autoscroll}} class="boxel-thread-usage">
       <:header>
         <Boxel::ThreadHeader @title="Project Title" />
       </:header>
 
       <:content>
         <Boxel::DateDivider @date={{dayjs-format (now)}} />
-        <Boxel::ThreadMessage
-          @name="Cardbot"
-          @hideName={{true}}
-          @imgURL={{this.cardBotIcon}}
-        >
-          Hello, it's nice to see you!
-        </Boxel::ThreadMessage>
+        {{#each this.messages}}
+          <Boxel::ThreadMessage
+            @name="Cardbot"
+            @hideName={{true}}
+            @imgURL={{this.cardBotIcon}}
+          >
+            Hello, it's nice to see you!
+          </Boxel::ThreadMessage>
+        {{/each}}
       </:content>
     </Boxel::Thread>
   </:example>
+
+  <:api as |Args|>
+  <Args.Bool
+    @name="autoscroll"
+    @description="Whether to automatically scroll down to newly added elements if the user is close enough to the end of the thread (see the autoscroll modifier)."
+    @default={{false}}
+    @value={{this.autoscroll}}
+    @onInput={{fn (mut this.autoscroll)}}
+  />
+  </:api>
 </Freestyle::Usage>
 
 <Freestyle::Usage @slug="Thread-with-workflow">

--- a/addon/components/boxel/thread/usage.ts
+++ b/addon/components/boxel/thread/usage.ts
@@ -1,3 +1,5 @@
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import CardBot from '@cardstack/boxel/usage-support/images/orgs/cardbot.svg';
 import User from '@cardstack/boxel/usage-support/images/users/Gary-Walker.jpg';
@@ -38,4 +40,10 @@ export default class ThreadMessageUsageComponent extends Component {
   orgGroup = ORG_GROUP;
   userGroup = USER_GROUP;
   milestones = MILESTONES;
+  @tracked messages: number[] = [1];
+  @tracked autoscroll = false;
+
+  @action addMessage(): void {
+    this.messages = [...this.messages, 1];
+  }
 }

--- a/addon/modifiers/autoscroll.ts
+++ b/addon/modifiers/autoscroll.ts
@@ -1,7 +1,7 @@
 import { modifier } from 'ember-modifier';
 
 interface AutoscrollOptions {
-  disable?: boolean;
+  enabled?: boolean;
   lockThreshold?: number;
 }
 
@@ -17,7 +17,10 @@ function autoscroll(
   _optionsParams: unknown[] = [], // eslint-disable-line @typescript-eslint/no-unused-vars
   optionsHash: AutoscrollOptions = {}
 ) {
-  if (optionsHash.disable) {
+  if (
+    Object.prototype.hasOwnProperty.call(optionsHash, 'enabled') &&
+    !optionsHash.enabled
+  ) {
     return;
   }
 

--- a/addon/modifiers/autoscroll.ts
+++ b/addon/modifiers/autoscroll.ts
@@ -1,6 +1,7 @@
 import { modifier } from 'ember-modifier';
 
 interface AutoscrollOptions {
+  disable?: boolean;
   lockThreshold?: number;
 }
 
@@ -16,6 +17,10 @@ function autoscroll(
   _optionsParams: unknown[] = [], // eslint-disable-line @typescript-eslint/no-unused-vars
   optionsHash: AutoscrollOptions = {}
 ) {
+  if (optionsHash.disable) {
+    return;
+  }
+
   const options = {
     ...optionsHash,
   };

--- a/addon/modifiers/autoscroll.ts
+++ b/addon/modifiers/autoscroll.ts
@@ -17,8 +17,11 @@ function autoscroll(
   _optionsParams: unknown[] = [], // eslint-disable-line @typescript-eslint/no-unused-vars
   optionsHash: AutoscrollOptions = {}
 ) {
+  // if the 'enabled' property was provided and falsey (including null and undefined), we consider this disabled
+  // when we used Object.prototype.hasOwnProperty, getOwnPropertyDescriptor caused
+  // a failing assertion in tests with ember-source@3.27
   if (
-    Object.prototype.hasOwnProperty.call(optionsHash, 'enabled') &&
+    Reflect.ownKeys(optionsHash).includes('enabled') &&
     !optionsHash.enabled
   ) {
     return;


### PR DESCRIPTION
To help with `prefers-reduced-motion: reduce`, allow consumers to turn off autoscrolling in the thread component. For use in https://github.com/cardstack/cardstack/pull/1697